### PR TITLE
Use Docker build secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,7 @@ custom `Dockerfile`s need to be structured
 with the same build stages as `add_me_to_your_PATH/Dockerfile.template`.
 
 `--julia` is the julia command to be run in the container, as a
-comma-separated list of "-quoted words. Defaults to `"julia"` if
-`--image` is set, or `"julia", "--sysimage=/deps.so"` if it is not
-since this is what the default `Dockerfile` is set up to run.
+comma-separated list of "-quoted words. Defaults to `"julia"`.
 
 If no `--image=...` is passed in, `julia_pod` will call `accounts.sh`
 and then `build_image` to build one. For this:
@@ -128,6 +126,14 @@ especially if sysimages are involved. However:
 - subsequently it's fairly quick to spin up.
 - you can add deps from within your julia session, and the folder 
   syncing will mirror them to your local project folder.
+
+
+### private package registry
+
+If you use a private Julia packages you can add your private package
+registry by setting the environmental variable `PRIVATE_REGISTRY_URL`.
+The environmental variable `GITHUB_TOKEN_FILE` specifies path to the
+credentials file used when authenticating.
 
 
 ### set your project up for faster load times

--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ vars for your cluster:
 - `KUBERNETES_SERVICEACCOUNT`
 - `IMAGE_REPO` -- a docker repo from which container images can be pulled
 
-To give your `julia_pod` access to private packages,
-uncomment and adapt the `# Optionally install a private Registry`
-line in `add_me_to_your_PATH/Dockerfile.template`.
+To give your `julia_pod` access to private packages set the following ENV vars:
+- `PRIVATE_REGISTRY_URL` -- URL to the private Julia package registry
+- `GITHUB_TOKEN_FILE` -- Path to a file containing [Personal Access Token](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token) with "repo" scope access.
 
 Then just add `add_me_to_your_PATH/` to your path, or call
 `/path/to/add_me_to_your_PATH/julia_pod`.

--- a/README.md
+++ b/README.md
@@ -110,9 +110,9 @@ and then `build_image` to build one. For this:
   (for example for AWS ECR, this is done by ensuring that the
   [credential helper](https://github.com/awslabs/amazon-ecr-credential-helper)
   is installed and Docker is configured to use it).
-- if you have a `GITUHB_TOKEN` that gives access to private github
-  repositories, you can pass it in as the `GITHUB_TOKEN` environment
-  variable.
+- if you have a GitHub token that gives access to private github
+  repositories, you can provide that secret by storing it in a file and
+  specifying the path in the environment variable: `GITHUB_TOKEN_FILE`.
 
 If you do not have a `Dockerfile` or `driver.yaml.template`
 in your julia project root dir, default versions of these will be

--- a/add_me_to_your_PATH/Dockerfile.template
+++ b/add_me_to_your_PATH/Dockerfile.template
@@ -75,8 +75,11 @@ RUN --mount=type=secret,id=github_token \
 FROM sysimage-image as precompile-image
 
 # install Revise and PProf, even if not a dep of project
+ARG ADD_UTILS="true"
 RUN --mount=type=secret,id=github_token \
-    julia -e 'using Pkg; Pkg.add("Revise"); Pkg.add("PProf"); Pkg.instantiate()'
+    if [ "$ADD_UTILS" == "true" ]; then \
+        julia -e 'using Pkg; Pkg.add("Revise"); Pkg.add("PProf"); Pkg.instantiate()'; \
+    fi
 RUN mkdir -p /root/.julia/config
 
 COPY Project.toml Manifest.toml /JuliaProject

--- a/add_me_to_your_PATH/Dockerfile.template
+++ b/add_me_to_your_PATH/Dockerfile.template
@@ -19,8 +19,9 @@ FROM nvidia/cuda:${CUDA_VERSION}-cudnn8-devel-ubuntu20.04 as base
 # ubuntu 20.04 is derived from debian buster
 COPY --from=julia-base /usr/local/julia /usr/local/julia
 
-RUN apt-get update && apt-get install -y curl \
-    && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && \
+    apt-get install -y curl git && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JULIA_PATH /usr/local/julia
 ENV PATH $JULIA_PATH/bin:$PATH
@@ -29,10 +30,11 @@ ENV JULIA_DEBUG CUDA
 ENV CUDA_HOME /usr/local/cuda
 ENV PYTHON ""
 
-# git config to access private repos, if GITHUB_TOKEN is non-empty
-ARG GITHUB_TOKEN
-RUN [[ -z "${GITHUB_TOKEN}"]] || { echo "[url \"https://${GITHUB_TOKEN}:@github.com/\"]" >  /root/.gitconfig; }
-RUN [[ -z "${GITHUB_TOKEN}"]] || { echo "	insteadOf = https://github.com/" >> /root/.gitconfig; }
+# Install github-token-helper to allow for private repo access via `docker build --secret id=github_token,src=token.txt ...`
+RUN curl -L https://raw.githubusercontent.com/beacon-biosignals/github-token-helper/v0.1.1/github-token-helper -o $HOME/.github-token-helper && \
+    chmod +x $HOME/.github-token-helper && \
+    git config --global credential.https://github.com.helper "$HOME/.github-token-helper -f /run/secrets/github_token -e GITHUB_TOKEN"
+
 
 FROM base as sysimage-image
 
@@ -43,10 +45,12 @@ RUN apt-get update && apt-get install -y \
     gcc \
     && rm -rf /var/lib/apt/lists/*
 
-RUN julia -e 'using Pkg; Pkg.Registry.add("General")'
-
-# Optionally install a private Registry
-# RUN julia -e 'using Pkg; Pkg.Registry.add(RegistrySpec(name="MyPrivate", url="https://github.com/my-github-org/MyPrivateRegistry.git"))'
+# Install the General registry and optionally a private registry
+ARG PRIVATE_REGISTRY_URL=""
+RUN --mount=type=secret,id=github_token \
+    julia -e 'using Pkg; \
+              !isempty(ENV["PRIVATE_REGISTRY_URL"]) && Pkg.Registry.add(RegistrySpec(url=ENV["PRIVATE_REGISTRY_URL"])); \
+              Pkg.Registry.add("General")'
 
 # Instantiate the Julia project environment
 COPY --from=pinned-extractor *Project.toml *Manifest.toml /JuliaProject/
@@ -54,7 +58,8 @@ COPY --from=pinned-extractor *Project.toml *Manifest.toml /JuliaProject/
 RUN julia --project=/JuliaProject -e 'using Pkg; Pkg.instantiate(); Pkg.build(); Pkg.precompile()'
 
 COPY sysimage.jl /JuliaProject/sysimage.jl
-RUN julia --project=/JuliaProject -e 'include("/JuliaProject/sysimage.jl")'
+RUN --mount=type=secret,id=github_token \
+    julia --project=/JuliaProject -e 'include("/JuliaProject/sysimage.jl")'
 
 
 #####
@@ -70,7 +75,8 @@ RUN julia --project=/JuliaProject -e 'include("/JuliaProject/sysimage.jl")'
 FROM sysimage-image as precompile-image
 
 # install Revise and PProf, even if not a dep of project
-RUN julia -e 'using Pkg; Pkg.add("Revise"); Pkg.add("PProf"); Pkg.instantiate()'
+RUN --mount=type=secret,id=github_token \
+    julia -e 'using Pkg; Pkg.add("Revise"); Pkg.add("PProf"); Pkg.instantiate()'
 RUN mkdir -p /root/.julia/config
 
 COPY Project.toml Manifest.toml /JuliaProject
@@ -84,12 +90,8 @@ RUN julia --project=/JuliaProject --sysimage=/deps.so -e 'using Pkg; Pkg.instant
 ##### project initialization stage
 #####
 # By separating this stage out from the previous stages, we achieve nicer cache
-# invalidation behavior, a slimmer final image, and keep the GITHUB_TOKEN out of
-# the build history of the final image (though it can still show up in intermediate
-# layers/history of the `pre-stage` image--EXCEPT here we're explicitly
-# copying it back into the final image so that you can add private deps during
-# your session.)
-#  In particular, changing content in
+# invalidation behavior, a slimmer final image.
+# In particular, changing content in
 # `src/` will invalidate the Docker cache for the stage below but will NOT
 # invalidate the stage above, including the slow sysimage creation step.
 

--- a/add_me_to_your_PATH/Dockerfile.template
+++ b/add_me_to_your_PATH/Dockerfile.template
@@ -87,7 +87,7 @@ COPY Project.toml Manifest.toml /JuliaProject
 # comment out if you don't have any `dev --local` deps
 COPY dev/ /JuliaProject/dev/
 
-RUN julia --project=/JuliaProject --sysimage=/deps.so -e 'using Pkg; Pkg.instantiate(); Pkg.build(); Pkg.precompile()'
+RUN julia --project=/JuliaProject -e 'using Pkg; Pkg.instantiate(); Pkg.build(); Pkg.precompile()'
 
 #####
 ##### project initialization stage
@@ -103,7 +103,7 @@ FROM base as project
 # copy over artifacts generated during the `precompile-image` stage
 COPY --from=precompile-image /JuliaProject/ /JuliaProject/
 COPY --from=precompile-image /root/.julia /root/.julia
-COPY --from=precompile-image /deps.so /deps.so
+COPY --from=precompile-image /usr/local/julia/lib/julia/sys.* /usr/local/julia/lib/julia/
 
 # contains github token, you may want to remove this file
 # but then adding private deps during julia_pod sessions will not work
@@ -113,7 +113,7 @@ COPY --from=precompile-image /root/.gitconfig /root/.gitconfig
 COPY src/ JuliaProject/src/
 
 # final precompilation step
-RUN julia --project=/JuliaProject --sysimage=/deps.so -e 'using Pkg; Pkg.build(); Pkg.precompile()'
+RUN julia --project=/JuliaProject -e 'using Pkg; Pkg.build(); Pkg.precompile()'
 
 ENV JULIA_PROJECT @.
 
@@ -123,4 +123,4 @@ WORKDIR /JuliaProject
 RUN mkdir -p /root/.julia/config
 RUN echo 'n=8; sleep(n); println("done waiting $n secs for logs/repl_history.jl to sync...")' >> /root/.julia/config/startup.jl
 
-CMD julia --sysimage=/deps.so
+CMD julia

--- a/add_me_to_your_PATH/Dockerfile.template
+++ b/add_me_to_your_PATH/Dockerfile.template
@@ -8,9 +8,10 @@ FROM julia:${JULIA_VERSION}-buster as pinned-extractor
 COPY *Project.toml *Manifest.toml .
 
 # Remove all packages that are not pinned or are not a dependency of a pinned package
-RUN julia --project=. -e 'using Pkg;\
-                          pinned = [p.name for p in values(Pkg.dependencies()) if p.is_pinned];\
-                          Pkg.rm([p for p in keys(Pkg.project().dependencies) if p ∉ pinned])'
+RUN julia --project=. -e 'using Pkg; \
+                          pinned = [p.name for p in values(Pkg.dependencies()) if p.is_pinned]; \
+                          unpinned = [p for p in keys(Pkg.project().dependencies) if p ∉ pinned]; \
+                          isempty(unpinned) || Pkg.rm(unpinned)'
 
 FROM julia:${JULIA_VERSION}-buster as julia-base
 
@@ -82,7 +83,7 @@ RUN --mount=type=secret,id=github_token \
     fi
 RUN mkdir -p /root/.julia/config
 
-COPY Project.toml Manifest.toml /JuliaProject
+COPY *Project.toml *Manifest.toml /JuliaProject
 
 # comment out if you don't have any `dev --local` deps
 COPY dev/ /JuliaProject/dev/

--- a/add_me_to_your_PATH/Dockerfile.template
+++ b/add_me_to_your_PATH/Dockerfile.template
@@ -36,6 +36,13 @@ RUN curl -L https://raw.githubusercontent.com/beacon-biosignals/github-token-hel
     chmod +x $HOME/.github-token-helper && \
     git config --global credential.https://github.com.helper "$HOME/.github-token-helper -f /run/secrets/github_token -e GITHUB_TOKEN"
 
+# Install the General registry and optionally a private registry
+ARG PRIVATE_REGISTRY_URL=""
+RUN --mount=type=secret,id=github_token \
+    julia -e 'using Pkg; \
+              !isempty(ENV["PRIVATE_REGISTRY_URL"]) && Pkg.Registry.add(RegistrySpec(url=ENV["PRIVATE_REGISTRY_URL"])); \
+              Pkg.Registry.add("General")'
+
 
 FROM base as sysimage-image
 
@@ -46,17 +53,11 @@ RUN apt-get update && apt-get install -y \
     gcc \
     && rm -rf /var/lib/apt/lists/*
 
-# Install the General registry and optionally a private registry
-ARG PRIVATE_REGISTRY_URL=""
-RUN --mount=type=secret,id=github_token \
-    julia -e 'using Pkg; \
-              !isempty(ENV["PRIVATE_REGISTRY_URL"]) && Pkg.Registry.add(RegistrySpec(url=ENV["PRIVATE_REGISTRY_URL"])); \
-              Pkg.Registry.add("General")'
-
 # Instantiate the Julia project environment
 COPY --from=pinned-extractor *Project.toml *Manifest.toml /JuliaProject/
 
-RUN julia --project=/JuliaProject -e 'using Pkg; Pkg.instantiate(); Pkg.build(); Pkg.precompile()'
+RUN --mount=type=secret,id=github_token \
+    julia --project=/JuliaProject -e 'using Pkg; Pkg.instantiate(); Pkg.build(); Pkg.precompile()'
 
 COPY sysimage.jl /JuliaProject/sysimage.jl
 RUN --mount=type=secret,id=github_token \
@@ -88,7 +89,8 @@ COPY *Project.toml *Manifest.toml /JuliaProject
 # comment out if you don't have any `dev --local` deps
 COPY dev/ /JuliaProject/dev/
 
-RUN julia --project=/JuliaProject -e 'using Pkg; Pkg.instantiate(); Pkg.build(); Pkg.precompile()'
+RUN --mount=type=secret,id=github_token \
+    julia --project=/JuliaProject -e 'using Pkg; Pkg.instantiate(); Pkg.build(); Pkg.precompile()'
 
 #####
 ##### project initialization stage

--- a/add_me_to_your_PATH/accounts.sh
+++ b/add_me_to_your_PATH/accounts.sh
@@ -8,7 +8,7 @@
 
 # example setup
 
-CALLER_ID=$(aws sts get-caller-identity)
+CALLER_ID=$(aws sts get-caller-identity --output json)
 AWS_ACCOUNT_ID=$(echo "$CALLER_ID" | jq -r .Account)
 REGION="us-east-2"
 PROJECT_NAME=$(echo "$CALLER_ID" | grep -oP 'assumed-role/\K[^/]*')

--- a/add_me_to_your_PATH/accounts.sh
+++ b/add_me_to_your_PATH/accounts.sh
@@ -10,6 +10,7 @@
 
 CALLER_ID=$(aws sts get-caller-identity --output json)
 AWS_ACCOUNT_ID=$(echo "$CALLER_ID" | jq -r .Account)
+AWS_USER_ID=$(echo "$CALLER_ID" | jq -r .UserId)
 REGION="us-east-2"
 PROJECT_NAME=${PROJECT_NAME:-$(echo "$CALLER_ID" | grep -oP 'assumed-role/\K[^/]*')}
 

--- a/add_me_to_your_PATH/accounts.sh
+++ b/add_me_to_your_PATH/accounts.sh
@@ -11,7 +11,7 @@
 CALLER_ID=$(aws sts get-caller-identity --output json)
 AWS_ACCOUNT_ID=$(echo "$CALLER_ID" | jq -r .Account)
 REGION="us-east-2"
-PROJECT_NAME=$(echo "$CALLER_ID" | grep -oP 'assumed-role/\K[^/]*')
+PROJECT_NAME=${PROJECT_NAME:-$(echo "$CALLER_ID" | grep -oP 'assumed-role/\K[^/]*')}
 
 # above is setup for 3 required vars below
 

--- a/add_me_to_your_PATH/build_image
+++ b/add_me_to_your_PATH/build_image
@@ -95,6 +95,7 @@ docker buildx build --target base \
                     --build-arg "JULIA_VERSION=$JULIA_VERSION" \
                     --build-arg "CUDA_VERSION=$CUDA_VERSION" \
                     --secret id=github_token,src="$GITHUB_TOKEN_FILE" \
+                    --build-arg PRIVATE_REGISTRY_URL="$PRIVATE_REGISTRY_URL" \
                     --build-arg "BUILDKIT_INLINE_CACHE=1" \
                     --cache-from "$BASE_IMAGE_CACHE" \
                     -t "$BASE_IMAGE_CACHE" --push .
@@ -106,6 +107,7 @@ docker buildx build --target sysimage-image \
                     --build-arg "BUILDKIT_INLINE_CACHE=1" \
                     --build-arg "JULIA_VERSION=$JULIA_VERSION" \
                     --build-arg "CUDA_VERSION=$CUDA_VERSION" \
+                    --build-arg PRIVATE_REGISTRY_URL="$PRIVATE_REGISTRY_URL" \
                     --cache-from "$BASE_IMAGE_CACHE" \
                     --cache-from "$SYSIMAGE_IMAGE_CACHE" \
                     -t "$SYSIMAGE_IMAGE_CACHE" --push .
@@ -117,6 +119,7 @@ docker buildx build --target precompile-image \
                     --build-arg "BUILDKIT_INLINE_CACHE=1" \
                     --build-arg "JULIA_VERSION=$JULIA_VERSION" \
                     --build-arg "CUDA_VERSION=$CUDA_VERSION" \
+                    --build-arg PRIVATE_REGISTRY_URL="$PRIVATE_REGISTRY_URL" \
                     --cache-from "$BASE_IMAGE_CACHE" \
                     --cache-from "$SYSIMAGE_IMAGE_CACHE" \
                     --cache-from "$PRECOMPILE_IMAGE_CACHE" \
@@ -128,6 +131,7 @@ docker buildx build --secret id=github_token,src="$GITHUB_TOKEN_FILE" \
                     --build-arg "BUILDKIT_INLINE_CACHE=1" \
                     --build-arg "JULIA_VERSION=$JULIA_VERSION" \
                     --build-arg "CUDA_VERSION=$CUDA_VERSION" \
+                    --build-arg PRIVATE_REGISTRY_URL="$PRIVATE_REGISTRY_URL" \
                     --cache-from "$BASE_IMAGE_CACHE" \
                     --cache-from "$SYSIMAGE_IMAGE_CACHE" \
                     --cache-from "$PRECOMPILE_IMAGE_CACHE" \

--- a/add_me_to_your_PATH/build_image
+++ b/add_me_to_your_PATH/build_image
@@ -30,15 +30,21 @@ bail() {
 }
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+BUILD_ARGS=()
 
 [[ -z ${IMAGE_REPO} ]] && {
     bail "IMAGE_REPO env variable must be set, add it to $SCRIPT_DIR/accounts.sh"
 }
 
-[[ -z "$GITHUB_TOKEN_FILE" ]] && {
+if [[ -n "$GITHUB_TOKEN_FILE" ]]; then
+    BUILD_ARGS+=(--secret id=github_token,src="$GITHUB_TOKEN_FILE")
+else
     warn "GITHUB_TOKEN_FILE env variable not set, private GitHub repos will not be accessible."
-    GITHUB_TOKEN_FILE=""
-}
+fi
+
+if [[ -n "$PRIVATE_REGISTRY_URL" ]]; then
+    BUILD_ARGS+=(--build-arg PRIVATE_REGISTRY_URL="$PRIVATE_REGISTRY_URL")
+fi
 
 [[ -f Project.toml ]] || {
     bail "no Project.toml found in $PWD"
@@ -91,23 +97,23 @@ IMAGE_TAG="${IMAGE_REPO}:${VERSIONS_TAG}_${GIT_INFO}_commit-${GIT_COMMIT}_sha1-$
 
 log "building and pushing sysimage-image with ECR_TAG = $BASE_IMAGE_CACHE"
 
+
+
 docker buildx build --target base \
                     --build-arg "JULIA_VERSION=$JULIA_VERSION" \
                     --build-arg "CUDA_VERSION=$CUDA_VERSION" \
-                    --secret id=github_token,src="$GITHUB_TOKEN_FILE" \
-                    --build-arg PRIVATE_REGISTRY_URL="$PRIVATE_REGISTRY_URL" \
                     --build-arg "BUILDKIT_INLINE_CACHE=1" \
+                    ${BUILD_ARGS[@]} \
                     --cache-from "$BASE_IMAGE_CACHE" \
                     -t "$BASE_IMAGE_CACHE" --push .
 
 log "building and pushing sysimage-image with ECR_TAG = $SYSIMAGE_IMAGE_CACHE"
 
 docker buildx build --target sysimage-image \
-                    --secret id=github_token,src="$GITHUB_TOKEN_FILE" \
                     --build-arg "BUILDKIT_INLINE_CACHE=1" \
                     --build-arg "JULIA_VERSION=$JULIA_VERSION" \
                     --build-arg "CUDA_VERSION=$CUDA_VERSION" \
-                    --build-arg PRIVATE_REGISTRY_URL="$PRIVATE_REGISTRY_URL" \
+                    ${BUILD_ARGS[@]} \
                     --cache-from "$BASE_IMAGE_CACHE" \
                     --cache-from "$SYSIMAGE_IMAGE_CACHE" \
                     -t "$SYSIMAGE_IMAGE_CACHE" --push .
@@ -115,11 +121,10 @@ docker buildx build --target sysimage-image \
 log "building and loading precompile-image with TAG = $PRECOMPILE_IMAGE_CACHE"
 
 docker buildx build --target precompile-image \
-                    --secret id=github_token,src="$GITHUB_TOKEN_FILE" \
                     --build-arg "BUILDKIT_INLINE_CACHE=1" \
                     --build-arg "JULIA_VERSION=$JULIA_VERSION" \
                     --build-arg "CUDA_VERSION=$CUDA_VERSION" \
-                    --build-arg PRIVATE_REGISTRY_URL="$PRIVATE_REGISTRY_URL" \
+                    ${BUILD_ARGS[@]} \
                     --cache-from "$BASE_IMAGE_CACHE" \
                     --cache-from "$SYSIMAGE_IMAGE_CACHE" \
                     --cache-from "$PRECOMPILE_IMAGE_CACHE" \
@@ -127,11 +132,10 @@ docker buildx build --target precompile-image \
 
 log "building and pushing image with ECR_TAG = $IMAGE_TAG"
 
-docker buildx build --secret id=github_token,src="$GITHUB_TOKEN_FILE" \
-                    --build-arg "BUILDKIT_INLINE_CACHE=1" \
+docker buildx build --build-arg "BUILDKIT_INLINE_CACHE=1" \
                     --build-arg "JULIA_VERSION=$JULIA_VERSION" \
                     --build-arg "CUDA_VERSION=$CUDA_VERSION" \
-                    --build-arg PRIVATE_REGISTRY_URL="$PRIVATE_REGISTRY_URL" \
+                    ${BUILD_ARGS[@]} \
                     --cache-from "$BASE_IMAGE_CACHE" \
                     --cache-from "$SYSIMAGE_IMAGE_CACHE" \
                     --cache-from "$PRECOMPILE_IMAGE_CACHE" \

--- a/add_me_to_your_PATH/build_image
+++ b/add_me_to_your_PATH/build_image
@@ -35,9 +35,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
     bail "IMAGE_REPO env variable must be set, add it to $SCRIPT_DIR/accounts.sh"
 }
 
-[[ -z "$GITHUB_TOKEN" ]] && {
-    warn "GITHUB_TOKEN env variable not set, private github repos will not be accessible."
-    GITHUB_TOKEN=""
+[[ -z "$GITHUB_TOKEN_FILE" ]] && {
+    warn "GITHUB_TOKEN_FILE env variable not set, private GitHub repos will not be accessible."
+    GITHUB_TOKEN_FILE=""
 }
 
 [[ -f Project.toml ]] || {
@@ -98,7 +98,7 @@ log "building and pushing sysimage-image with ECR_TAG = $BASE_IMAGE_CACHE"
 docker buildx build --target base \
                     --build-arg "JULIA_VERSION=$JULIA_VERSION" \
                     --build-arg "CUDA_VERSION=$CUDA_VERSION" \
-                    --build-arg "GITHUB_TOKEN=$GITHUB_TOKEN" \
+                    --secret id=github_token,src="$GITHUB_TOKEN_FILE" \
                     --build-arg "BUILDKIT_INLINE_CACHE=1" \
                     --cache-from "$BASE_IMAGE_CACHE" \
                     -t "$BASE_IMAGE_CACHE" --push .
@@ -106,7 +106,7 @@ docker buildx build --target base \
 log "building and pushing sysimage-image with ECR_TAG = $SYSIMAGE_IMAGE_CACHE"
 
 docker buildx build --target sysimage-image \
-                    --build-arg "GITHUB_TOKEN=$GITHUB_TOKEN" \
+                    --secret id=github_token,src="$GITHUB_TOKEN_FILE" \
                     --build-arg "BUILDKIT_INLINE_CACHE=1" \
                     --build-arg "JULIA_VERSION=$JULIA_VERSION" \
                     --build-arg "CUDA_VERSION=$CUDA_VERSION" \
@@ -117,7 +117,7 @@ docker buildx build --target sysimage-image \
 log "building and loading precompile-image with TAG = $PRECOMPILE_IMAGE_CACHE"
 
 docker buildx build --target precompile-image \
-                    --build-arg "GITHUB_TOKEN=$GITHUB_TOKEN" \
+                    --secret id=github_token,src="$GITHUB_TOKEN_FILE" \
                     --build-arg "BUILDKIT_INLINE_CACHE=1" \
                     --build-arg "JULIA_VERSION=$JULIA_VERSION" \
                     --build-arg "CUDA_VERSION=$CUDA_VERSION" \
@@ -128,7 +128,7 @@ docker buildx build --target precompile-image \
 
 log "building and pushing image with ECR_TAG = $IMAGE_TAG"
 
-docker buildx build --build-arg "GITHUB_TOKEN=$GITHUB_TOKEN" \
+docker buildx build --secret id=github_token,src="$GITHUB_TOKEN_FILE" \
                     --build-arg "BUILDKIT_INLINE_CACHE=1" \
                     --build-arg "JULIA_VERSION=$JULIA_VERSION" \
                     --build-arg "CUDA_VERSION=$CUDA_VERSION" \

--- a/add_me_to_your_PATH/build_image
+++ b/add_me_to_your_PATH/build_image
@@ -44,10 +44,6 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
     bail "no Project.toml found in $PWD"
 }
 
-[[ -f Manifest.toml ]] || {
-    bail "no Manifest.toml found in $PWD"
-}
-
 [[ -d src ]] || {
     bail "no src/ found in $PWD"
 }

--- a/add_me_to_your_PATH/driver.yaml.template
+++ b/add_me_to_your_PATH/driver.yaml.template
@@ -11,6 +11,12 @@ spec:
             containers:
                 - name: driver
                   image: ${IMAGE_TAG}
+                  env:
+                      - name: GITHUB_TOKEN
+                        valueFrom:
+                            secretKeyRef:
+                                name: ${SECRET_NAME}
+                                key: GITHUB_TOKEN
                   resources:
                       limits:
                           memory: 16Gi

--- a/add_me_to_your_PATH/julia_pod
+++ b/add_me_to_your_PATH/julia_pod
@@ -107,10 +107,6 @@ DRIVER_YAML="driver-${RUNID}.yaml"
 # if `julia_pod` was called with args, replace values in `driver.yaml`
 [[ -n "${JULIA_COMMAND}" ]] || {
     JULIA_COMMAND='"julia"'
-    [[ -n ${IMAGE_TAG_ARG} ]] || {
-        # we are using image built by julia_pod, which builds a sysimage
-        JULIA_COMMAND='"julia", "--sysimage=/deps.so"'
-    }
 }
 if [ -n "${args}" ]; then
     # user passed in some julia code to run

--- a/add_me_to_your_PATH/julia_pod
+++ b/add_me_to_your_PATH/julia_pod
@@ -115,13 +115,25 @@ fi
 JULIA_COMMAND="[${JULIA_COMMAND}]"
 echo $JULIA_COMMAND
 
+# generate a k8s secret name
+SECRET_NAME=$(echo "${AWS_USER_ID}" | tr '[:upper:]' '[:lower:]' | sed -e 's/[^a-z0-9]\+/-/g')
+
+
+if kubectl get secret $SECRET_NAME &>/dev/null; then
+    kubectl delete secret $SECRET_NAME
+fi
+
+# pod will fail to start unless secret and key are present. When `GITHUB_TOKEN_FILE` isn't set this will be populated with ""
+echo "GITHUB_TOKEN=$([ -z ${GITHUB_TOKEN_FILE} ] || cat ${GITHUB_TOKEN_FILE})" | kubectl create secret generic $SECRET_NAME --from-env-file=/dev/stdin
+
 # substitute ENV vars into driver.yaml.template > driver.yaml for this run
 log "Generating $DRIVER_YAML" \
     && IMAGE_TAG=$IMAGE_TAG \
         RUNID=$RUNID \
         KUBERNETES_SERVICEACCOUNT=$KUBERNETES_SERVICEACCOUNT \
         JULIA_COMMAND=$JULIA_COMMAND \
-            envsubst '${IMAGE_TAG} ${RUNID} ${KUBERNETES_SERVICEACCOUNT} ${JULIA_COMMAND}' <driver.yaml.template >$DRIVER_YAML
+        SECRET_NAME=$SECRET_NAME \
+            envsubst '${IMAGE_TAG} ${RUNID} ${KUBERNETES_SERVICEACCOUNT} ${JULIA_COMMAND} ${SECRET_NAME}' <driver.yaml.template >$DRIVER_YAML
 
 # launch job
 kubectl apply -f $DRIVER_YAML -n "$KUBERNETES_NAMESPACE"

--- a/add_me_to_your_PATH/sysimage.jl
+++ b/add_me_to_your_PATH/sysimage.jl
@@ -13,6 +13,9 @@ if project.ispackage && !isfile(modulefile)
     end
 end
 
+# Skip generating a system image when there are no dependencies
+isempty(project.dependencies) && exit(0)
+
 Pkg.add("PackageCompiler")
 
 using PackageCompiler, UUIDs
@@ -25,8 +28,8 @@ function main()
     packages = setdiff(packages, exclude)
     println("Creating sys image with deps being tracked from a registry:")
     println(packages)
-    create_sysimage(packages; sysimage_path="deps.so", cpu_target = "generic;sandybridge,-xsaveopt,clone_all;haswell,-rdrnd,base(1)")
-    Pkg.rm("PackageCompiler")
+    create_sysimage(packages; replace_default=true, cpu_target = "generic;sandybridge,-xsaveopt,clone_all;haswell,-rdrnd,base(1)")
 end
 
 main()
+Pkg.rm("PackageCompiler")


### PR DESCRIPTION
Uses [`github-token-helper`](https://github.com/beacon-biosignals/github-token-helper) to avoid embedding the secrets in the image layers. Additional changes include:

- Conditionally set a private package registry via `--build-arg PRIVATE_REGISTRY_URL=...`
- Conditionally install Revise and Pprof via the build arg `ADD_UTILS`
- Skip installing PackageCompiler and attempting to make a system image if no packages are to be included in the system image
- Replace the default system image when using `create_sysimage`. This makes it easier to handle the previous point. The original system image can be restored via PackageCompilers normal mechanisms

TODO:
- [x] Document `PRIVATE_REGISTRY_URL` in README
- [x] Investigate if there is a secure way of passing in the GitHub token when starting the pod
- [x] Validate `julia_pod` changes (my instance I used to test this is having issues)