### PR TITLE
Remove non-pinned packages more thoroughly

### DIFF
--- a/add_me_to_your_PATH/Dockerfile.template
+++ b/add_me_to_your_PATH/Dockerfile.template
@@ -10,7 +10,7 @@ COPY *Project.toml *Manifest.toml .
 # Remove all packages that are not pinned or are not a dependency of a pinned package
 RUN julia --project=. -e 'using Pkg;\
                           pinned = [p.name for p in values(Pkg.dependencies()) if p.is_pinned];\
-                          Pkg.rm([p for p in keys(Pkg.project().dependencies) if p ∉ pinned])'
+                          Pkg.rm([p for p in keys(Pkg.project().dependencies) if p ∉ pinned]; mode=Pkg.PKGMODE_MANIFEST)'
 
 FROM julia:${JULIA_VERSION}-buster as julia-base
 

--- a/add_me_to_your_PATH/Dockerfile.template
+++ b/add_me_to_your_PATH/Dockerfile.template
@@ -10,11 +10,10 @@ COPY *Project.toml *Manifest.toml .
 # Remove all packages that are not pinned recursively from the manifest
 # (stdlibs count as pinned)
 RUN julia --project=. -e 'using Pkg;\
-                          not_pinned = [p.name for p in values(Pkg.dependencies()) if\
-                                        p.is_direct_dep &&\
-                                        !p.is_pinned &&\
-                                        p.name ∉ values(Pkg.Types.stdlibs())];\
-                          isempty(not_pinned) || Pkg.rm(not_pinned; mode=Pkg.PKGMODE_MANIFEST)'
+                          unpinned = [p.name for p in values(Pkg.dependencies()) \
+                                      if p.is_direct_dep && !p.is_pinned && \
+                                      p.name ∉ values(Pkg.Types.stdlibs())]; \
+                          isempty(unpinned) || Pkg.rm(unpinned; mode=Pkg.PKGMODE_MANIFEST)'
 
 FROM julia:${JULIA_VERSION}-buster as julia-base
 

--- a/add_me_to_your_PATH/Dockerfile.template
+++ b/add_me_to_your_PATH/Dockerfile.template
@@ -7,11 +7,12 @@ FROM julia:${JULIA_VERSION}-buster as pinned-extractor
 
 COPY *Project.toml *Manifest.toml .
 
-# Remove all packages that are not pinned or are not a dependency of a pinned package
+# Remove all packages that are not pinned recursively from the manifest
+# (stdlibs count as pinned)
 RUN julia --project=. -e 'using Pkg;\
-                          not_pinned = [p.name for p in values(Pkg.dependencies()) if
-                                        p.is_direct_dep &&
-                                        !p.is_pinned &&
+                          not_pinned = [p.name for p in values(Pkg.dependencies()) if\
+                                        p.is_direct_dep &&\
+                                        !p.is_pinned &&\
                                         p.name ∉ values(Pkg.Types.stdlibs())];\
                           isempty(not_pinned) || Pkg.rm(not_pinned; mode=Pkg.PKGMODE_MANIFEST)'
 

--- a/add_me_to_your_PATH/Dockerfile.template
+++ b/add_me_to_your_PATH/Dockerfile.template
@@ -9,8 +9,11 @@ COPY *Project.toml *Manifest.toml .
 
 # Remove all packages that are not pinned or are not a dependency of a pinned package
 RUN julia --project=. -e 'using Pkg;\
-                          pinned = [p.name for p in values(Pkg.dependencies()) if p.is_pinned];\
-                          Pkg.rm([p for p in keys(Pkg.project().dependencies) if p ∉ pinned]; mode=Pkg.PKGMODE_MANIFEST)'
+                          not_pinned = [p.name for p in values(Pkg.dependencies()) if
+                                        p.is_direct_dep &&
+                                        !p.is_pinned &&
+                                        p.name ∉ values(Pkg.Types.stdlibs())];\
+                          isempty(not_pinned) || Pkg.rm(not_pinned; mode=Pkg.PKGMODE_MANIFEST)'
 
 FROM julia:${JULIA_VERSION}-buster as julia-base
 


### PR DESCRIPTION
This is easier explained with an example. Let's say I have AWSS3.jl and AWS.jl in my Project.toml, and I was working on AWS.jl so I un-pinned it so that I don't build it into my sysimage, because I want to be able to change versions (e.g. switch to my branch) without rebuilding it. Currently, we would `rm` AWS.jl from the Project before building the sysimage. But we would *not* rm AWSS3, which means that AWSS3 and *all of its dependencies* including AWS.jl would get baked into the sysimage. That means I would not be able to change versions of AWS.jl despite unpinning it.

Here, we use a Pkg command to remove the packages everywhere in the Manifest. That means if any package depends on a removed package, it is removed too. So in the example, we would not build either AWSS3 or AWS into the sysimage; they would both be removed since AWS.jl is not pinned.

That means if you do not pin something very low in the stack, you might end up removing most things from your sysimage. But that's basically the cost of editing something low in the stack I think; it seems unavoidable.