### PR TITLE
--port-forward flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ especially if sysimages are involved. However:
 - you can add deps from within your julia session, and the folder 
   syncing will mirror them to your local project folder.
 
-##### Example
+##### Examples
 
 From a julia project folder containing Pluto as a dependency,
 
@@ -140,6 +140,8 @@ julia_pod --port-forward=1234:1234 'using Pluto; Pluto.run()'
 
 will run a Pluto notebook and make `localhost:1234` forward to port
 `1234` in the pod running the notebook.
+
+`julia_pod --julia='"julia", "-t", "16"'` will launch a `julia_pod` with 16 threads.
 
 ### private package registry
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ folder to build an image from, and if that's not present it'll use
 custom `Dockerfile`s need to be structured
 with the same build stages as `add_me_to_your_PATH/Dockerfile.template`.
 
+`--port-forward` port forwards between localhost and the julia
+pod, e.g. `--port-forward=1234:1234`.
+
 `--julia` is the julia command to be run in the container, as a
 comma-separated list of "-quoted words. Defaults to `"julia"`.
 
@@ -127,6 +130,16 @@ especially if sysimages are involved. However:
 - you can add deps from within your julia session, and the folder 
   syncing will mirror them to your local project folder.
 
+##### Example
+
+From a julia project folder containing Pluto as a dependency,
+
+```bash
+julia_pod --port-forward=1234:1234 'using Pluto; Pluto.run()'
+```
+
+will run a Pluto notebook and make `localhost:1234` forward to port
+`1234` in the pod running the notebook.
 
 ### private package registry
 

--- a/add_me_to_your_PATH/julia_pod
+++ b/add_me_to_your_PATH/julia_pod
@@ -170,7 +170,7 @@ success "==== Pod $podname is RUNNING! ====\n\n"
 
 if [[ -n ${PORT_FORWARD} ]]; then
     sleep 1
-    kubectl port-forward pod/$podname $PORT_FORWARD >/tmp/kubectl-port-forward-$RUNID.log &
+    kubectl port-forward -n $KUBERNETES_NAMESPACE pod/$podname $PORT_FORWARD >/tmp/kubectl-port-forward-$RUNID.log &
     log "\n#====> port-forwarding $PORT_FORWARD, anyone else wanting to also connect can run: <====#"
     log "kubectl port-forward -n $KUBERNETES_NAMESPACE pod/$podname $PORT_FORWARD\n\n\n\n"
 fi

--- a/add_me_to_your_PATH/julia_pod
+++ b/add_me_to_your_PATH/julia_pod
@@ -38,10 +38,12 @@ while [ -n "$*" ]; do
         SYNC=false
     elif [[ "$1" == --image=* ]]; then
         IMAGE_TAG_ARG=$(echo $1 | cut -c 9-)
+    elif [[ "$1" == --port-forward=* ]]; then
+        PORT_FORWARD=$(echo $1 | cut -c 16-)
     elif [[ "$1" == --julia=* ]]; then
         JULIA_COMMAND=$(echo $1 | cut -c 9-)
     elif [ -n "${args}" ]; then
-        bail "julia_pod expects at most 2 arguments (the option '--no-sync' and a julia string), got ${nargs} args instead"
+        bail "julia_pod got unexpected option $1 instead of '--no-sync', '--image=' or '--port-forward=' (anything else is interpreted as a julia string)"
     elif [ -n "$1" ]; then
         args="$1"
     fi
@@ -166,14 +168,21 @@ success "==== Pod $podname is RUNNING! ====\n\n"
     echo ""
 }
 
+if [[ -n ${PORT_FORWARD} ]]; then
+    sleep 1
+    kubectl port-forward pod/$podname $PORT_FORWARD >/tmp/kubectl-port-forward-$RUNID.log &
+    log "\n#====> port-forwarding $PORT_FORWARD, anyone else wanting to also connect can run: <====#"
+    log "kubectl port-forward -n $KUBERNETES_NAMESPACE pod/$podname $PORT_FORWARD\n\n\n\n"
+fi
+
 # drop into REPL
 kubectl attach "pod/$podname" -c driver -it -n "$KUBERNETES_NAMESPACE" && echo ""
 
 # REPL session has exited, clean up
-[[ "${SYNC}" = true ]] && {
+[[ "${SYNC}" = true ]] || [[ -n ${PORT_FORWARD} ]] && {
     echo ""
     echo ""
-    log "Detached from pod, killing folder syncs!"
+    log "Detached from pod, killing folder syncs and/or port forwarding!"
     echo ""
 
     # kill background processes


### PR DESCRIPTION
I've noticed that running notebooks on k8s is a nice way to share the same session across users, as long as they have permissions for the same namespace.

So I added a `--port-forward` option to `julia_pod`, with an example for spinning up a Pluto notebook in the README.