### PR TITLE
allow customizing the RUNID variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ pod, e.g. `--port-forward=1234:1234`.
 `--julia` is the julia command to be run in the container, as a
 comma-separated list of "-quoted words. Defaults to `"julia"`.
 
+`--runid` will allow customizing the "run ID" used to choose the
+name of the kubernetes job.
+
 If no `--image=...` is passed in, `julia_pod` will call `accounts.sh`
 and then `build_image` to build one. For this:
 - your current directory must be a julia project root directory

--- a/README.md
+++ b/README.md
@@ -103,7 +103,9 @@ pod, e.g. `--port-forward=1234:1234`.
 comma-separated list of "-quoted words. Defaults to `"julia"`.
 
 `--runid` will allow customizing the "run ID" used to choose the
-name of the kubernetes job.
+name of the kubernetes job; if this flag is not provided,
+the kubernetes job and pod names will be a default
+based on the git repo and branch names.
 
 If no `--image=...` is passed in, `julia_pod` will call `accounts.sh`
 and then `build_image` to build one. For this:

--- a/add_me_to_your_PATH/julia_pod
+++ b/add_me_to_your_PATH/julia_pod
@@ -157,7 +157,7 @@ done
 
 sleep 1
 
-podname=$(kubectl get pods "--selector=job-name=$RUNID" --output=jsonpath='{.items[*].metadata.name}' -n "$KUBERNETES_NAMESPACE")
+podname=$(kubectl get pods "--selector=job-name=driver-$RUNID" --output=jsonpath='{.items[*].metadata.name}' -n "$KUBERNETES_NAMESPACE")
 
 log "Waiting for pod $podname to be ready..."
 until kubectl wait --for=condition=Ready "pod/$podname" -n "$KUBERNETES_NAMESPACE" --timeout=1s 2>/dev/null; do

--- a/add_me_to_your_PATH/julia_pod
+++ b/add_me_to_your_PATH/julia_pod
@@ -42,6 +42,8 @@ while [ -n "$*" ]; do
         PORT_FORWARD=$(echo $1 | cut -c 16-)
     elif [[ "$1" == --julia=* ]]; then
         JULIA_COMMAND=$(echo $1 | cut -c 9-)
+    elif [[ "$1" == --runid=* ]]; then
+        RUNID=$(echo $1 | cut -c 9-)
     elif [ -n "${args}" ]; then
         bail "julia_pod got unexpected option $1 instead of '--no-sync', '--image=' or '--port-forward=' (anything else is interpreted as a julia string)"
     elif [ -n "$1" ]; then
@@ -76,11 +78,18 @@ source "$SCRIPT_DIR/accounts.sh"
 if [[ -n ${IMAGE_TAG_ARG} ]]; then
     IMAGE_TAG=$IMAGE_TAG_ARG
     log "using docker IMAGE_TAG=${IMAGE_TAG}"
-    RUNID=$IMAGE_TAG
 else
     # build an image from pwd julia project
     source "$SCRIPT_DIR/build_image"
-    RUNID=$GIT_INFO
+fi
+
+if [[ -z "${RUNID}" ]]; then
+    echo "Setting RUNID"
+    if [[ -n ${IMAGE_TAG_ARG} ]]; then
+        RUNID=$IMAGE_TAG
+    else
+        RUNID=$GIT_INFO
+    fi
 fi
 
 # append day/time, both for podname quasi uniqueness and human-friendliness
@@ -142,7 +151,7 @@ kubectl apply -f $DRIVER_YAML -n "$KUBERNETES_NAMESPACE"
 
 log "Waiting for job to have active pod..."
 
-until kubectl get "job/$RUNID" -n "$KUBERNETES_NAMESPACE" -o 'jsonpath={..status.active}' | grep '1'; do
+until kubectl get "job/driver-$RUNID" -n "$KUBERNETES_NAMESPACE" -o 'jsonpath={..status.active}' | grep '1'; do
     printf "."
 done
 
@@ -192,4 +201,4 @@ kubectl attach "pod/$podname" -c driver -it -n "$KUBERNETES_NAMESPACE" && echo "
 log "====    ALL DONE    ===="
 log ""
 log "to force deleting job if your cluster is not set up to reap completed jobs with a ttlSecondsAfterFinished:"
-log "kubectl delete job/$RUNID -n $KUBERNETES_NAMESPACE --grace-period=0 --force=true"
+log "kubectl delete job/driver-$RUNID -n $KUBERNETES_NAMESPACE --grace-period=0 --force=true"

--- a/add_me_to_your_PATH/julia_pod
+++ b/add_me_to_your_PATH/julia_pod
@@ -151,13 +151,13 @@ kubectl apply -f $DRIVER_YAML -n "$KUBERNETES_NAMESPACE"
 
 log "Waiting for job to have active pod..."
 
-until kubectl get "job/driver-$RUNID" -n "$KUBERNETES_NAMESPACE" -o 'jsonpath={..status.active}' | grep '1'; do
+until kubectl get "job/$RUNID" -n "$KUBERNETES_NAMESPACE" -o 'jsonpath={..status.active}' | grep '1'; do
     printf "."
 done
 
 sleep 1
 
-podname=$(kubectl get pods "--selector=job-name=driver-$RUNID" --output=jsonpath='{.items[*].metadata.name}' -n "$KUBERNETES_NAMESPACE")
+podname=$(kubectl get pods "--selector=job-name=$RUNID" --output=jsonpath='{.items[*].metadata.name}' -n "$KUBERNETES_NAMESPACE")
 
 log "Waiting for pod $podname to be ready..."
 until kubectl wait --for=condition=Ready "pod/$podname" -n "$KUBERNETES_NAMESPACE" --timeout=1s 2>/dev/null; do
@@ -201,4 +201,4 @@ kubectl attach "pod/$podname" -c driver -it -n "$KUBERNETES_NAMESPACE" && echo "
 log "====    ALL DONE    ===="
 log ""
 log "to force deleting job if your cluster is not set up to reap completed jobs with a ttlSecondsAfterFinished:"
-log "kubectl delete job/driver-$RUNID -n $KUBERNETES_NAMESPACE --grace-period=0 --force=true"
+log "kubectl delete job/$RUNID -n $KUBERNETES_NAMESPACE --grace-period=0 --force=true"


### PR DESCRIPTION
I was getting errors that the job name was too long (using `--image` with a long image name that includes the ECR url), so I needed this to choose a shorter one.