### PR TITLE
update registries before Pkg.instantiate

### DIFF
--- a/add_me_to_your_PATH/Dockerfile.template
+++ b/add_me_to_your_PATH/Dockerfile.template
@@ -59,7 +59,7 @@ RUN apt-get update && apt-get install -y \
 COPY --from=pinned-extractor *Project.toml *Manifest.toml /JuliaProject/
 
 RUN --mount=type=secret,id=github_token \
-    julia --project=/JuliaProject -e 'using Pkg; Pkg.instantiate(); Pkg.build(); Pkg.precompile()'
+    julia --project=/JuliaProject -e 'using Pkg; Pkg.Registry.update(); Pkg.instantiate(); Pkg.build(); Pkg.precompile()'
 
 COPY sysimage.jl /JuliaProject/sysimage.jl
 RUN --mount=type=secret,id=github_token \


### PR DESCRIPTION
The `sysimage-image` build stage in `Dockerfile.template` depends on a docker `base` stage, which can be cached containing stale registry metadata. This can lead to build failure on `Pkg.instantiate` if updated package versions are no longer compatible with the stale registry metadata.

This tiny fix calls `Pkg.Registry.update()` before `Pkg.instantiate()` in the `sysimage-image` stage.