### PR TITLE
COPY ./* /JuliaProject/  at end of build

### DIFF
--- a/add_me_to_your_PATH/Dockerfile.template
+++ b/add_me_to_your_PATH/Dockerfile.template
@@ -120,6 +120,9 @@ COPY src/ JuliaProject/src/
 # final precompilation step
 RUN julia --project=/JuliaProject -e 'using Pkg; Pkg.build(); Pkg.precompile()'
 
+# copy over all other files without re-running precompile
+COPY ./* JuliaProject/
+
 ENV JULIA_PROJECT @.
 
 WORKDIR /JuliaProject

--- a/add_me_to_your_PATH/Dockerfile.template
+++ b/add_me_to_your_PATH/Dockerfile.template
@@ -121,7 +121,7 @@ COPY src/ JuliaProject/src/
 RUN julia --project=/JuliaProject -e 'using Pkg; Pkg.build(); Pkg.precompile()'
 
 # copy over all other files without re-running precompile
-COPY ./* JuliaProject/
+COPY * JuliaProject/
 
 ENV JULIA_PROJECT @.
 


### PR DESCRIPTION
without re-running julia precompile.

This makes the behaviour of `julia_pod` more consistent
between when `--no-sync` is passed in and when it isn't,
and makes it so that all the files that are synced by
`devsync` are there in the pod before the julia session starts.