### PR TITLE
really kill background devspace jobs on exit

### DIFF
--- a/add_me_to_your_PATH/julia_pod
+++ b/add_me_to_your_PATH/julia_pod
@@ -210,4 +210,3 @@ log "====    ALL DONE    ===="
 log ""
 log "to force deleting job if your cluster is not set up to reap completed jobs with a ttlSecondsAfterFinished:"
 log "kubectl delete job/$RUNID -n $KUBERNETES_NAMESPACE --grace-period=0 --force=true"
-


### PR DESCRIPTION
Previous `trap` didn't seem to work, leaving behind running (mostly harmless) `devspace` processes on exit.

This was causing `julia_pod` to hang on exit when run from a julia `run(pipeline(julia_pod))` context.