### PR TITLE
Couple of tweaks to help support concurrent `julia_pod` runs

### DIFF
--- a/add_me_to_your_PATH/julia_pod
+++ b/add_me_to_your_PATH/julia_pod
@@ -96,6 +96,7 @@ fi
 # sanitize to be valid dns entry
 RUNID="$(echo $RUNID | sed -e 's/[^a-zA-Z0-9]\+/-/g')-$(date +%a%Hh%Mm%S)"
 RUNID="$(echo ${RUNID##*(-)} | tr '[:upper:]' '[:lower:]')"
+RUNID=${RUNID}-$RANDOM
 
 DRIVER_YAML="driver-${RUNID}.yaml"
 
@@ -129,13 +130,8 @@ echo $JULIA_COMMAND
 # generate a k8s secret name
 SECRET_NAME=$(echo "${AWS_USER_ID}" | tr '[:upper:]' '[:lower:]' | sed -e 's/[^a-z0-9]\+/-/g')
 
-
-if kubectl get secret $SECRET_NAME &>/dev/null; then
-    kubectl delete secret $SECRET_NAME
-fi
-
 # pod will fail to start unless secret and key are present. When `GITHUB_TOKEN_FILE` isn't set this will be populated with ""
-echo "GITHUB_TOKEN=$([ -z ${GITHUB_TOKEN_FILE} ] || cat ${GITHUB_TOKEN_FILE})" | kubectl create secret generic $SECRET_NAME --from-env-file=/dev/stdin
+echo "GITHUB_TOKEN=$([ -z ${GITHUB_TOKEN_FILE} ] || cat ${GITHUB_TOKEN_FILE})" | kubectl create secret generic $SECRET_NAME --from-env-file=/dev/stdin || true
 
 #GIT_INFO="${GIT_REPO}_${GIT_BRANCH}"
 
@@ -201,6 +197,10 @@ kubectl attach "pod/$podname" -c driver -it -n "$KUBERNETES_NAMESPACE" && echo "
     echo ""
     log "Detached from pod, killing folder syncs and/or port forwarding!"
     echo ""
+
+    if kubectl get secret $SECRET_NAME &>/dev/null; then
+        kubectl delete secret $SECRET_NAME
+    fi
 
     # kill background processes
     kill $(jobs -p)


### PR DESCRIPTION
When running multiple `julia_pod`s in the same project
(typically via a script that launches them ~at the same time)
I've run into two issues that this fixes:
- RUNIDs are not unique enough
  (used to be based on datetime with second resolution)
- the same secret was being created and deleted, which often
  resulted in 'secret not found' errors

This fixes the RUNID uniqueness issue by appending a random number,
and lets secret creation failure not be fatal.

There might be better ways of ensuring secret lifecycles don't
clobber each other. Thoughts @omus?