### PR TITLE
use packagecompiler v1

### DIFF
--- a/add_me_to_your_PATH/build_image
+++ b/add_me_to_your_PATH/build_image
@@ -65,7 +65,7 @@ fi
 }
 
 [[ -z "${JULIA_VERSION}" ]] && {
-    JULIA_VERSION=1.7
+    JULIA_VERSION=1.6
     log "JULIA_VERSION environment variable not set, defaulting to ${JULIA_VERSION}"
 }
 

--- a/add_me_to_your_PATH/build_image
+++ b/add_me_to_your_PATH/build_image
@@ -65,7 +65,7 @@ fi
 }
 
 [[ -z "${JULIA_VERSION}" ]] && {
-    JULIA_VERSION=1.6
+    JULIA_VERSION=1.7
     log "JULIA_VERSION environment variable not set, defaulting to ${JULIA_VERSION}"
 }
 

--- a/add_me_to_your_PATH/sysimage.jl
+++ b/add_me_to_your_PATH/sysimage.jl
@@ -16,7 +16,7 @@ end
 # Skip generating a system image when there are no dependencies
 isempty(project.dependencies) && exit(0)
 
-Pkg.add("PackageCompiler")
+Pkg.add(name="PackageCompiler", version="1.7.7")
 
 using PackageCompiler, UUIDs
 

--- a/add_me_to_your_PATH/sysimage.jl
+++ b/add_me_to_your_PATH/sysimage.jl
@@ -16,7 +16,7 @@ end
 # Skip generating a system image when there are no dependencies
 isempty(project.dependencies) && exit(0)
 
-Pkg.add(name="PackageCompiler", version="1.7.7")
+Pkg.add(name="PackageCompiler", version="1")
 
 using PackageCompiler, UUIDs
 


### PR DESCRIPTION
PackageCompiler v2 no longer lets you replace the default julia sysimage. Upgrading to PackageCompiler v2 would require changing the `Dockerfile.template` to add a `--sysimage-...` to the `julia` invocations, or to set a `docker exec`-friendly equivalent of an alias.