### PR TITLE
Bugfix: quote strings

### DIFF
--- a/add_me_to_your_PATH/driver.yaml.template
+++ b/add_me_to_your_PATH/driver.yaml.template
@@ -1,11 +1,11 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-    name: ${RUNID}
+    name: "${RUNID}"
     labels:
-        git_repo: '${GIT_REPO}'
-        git_sha: '${GIT_COMMIT}'
-        git_branch: '${GIT_BRANCH}'
+        git_repo: "${GIT_REPO}"
+        git_sha: "${GIT_COMMIT}"
+        git_branch: "${GIT_BRANCH}"
 spec:
     ttlSecondsAfterFinished: 10
     backoffLimit: 0
@@ -14,9 +14,9 @@ spec:
             annotations:
                 cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
             labels:
-                git_repo: '${GIT_REPO}'
-                git_sha: '${GIT_COMMIT}'
-                git_branch: '${GIT_BRANCH}'
+                git_repo: "${GIT_REPO}"
+                git_sha: "${GIT_COMMIT}"
+                git_branch: "${GIT_BRANCH}"
         spec:
             serviceAccountName: '${KUBERNETES_SERVICEACCOUNT}'
             restartPolicy: Never

--- a/add_me_to_your_PATH/driver.yaml.template
+++ b/add_me_to_your_PATH/driver.yaml.template
@@ -3,9 +3,9 @@ kind: Job
 metadata:
     name: ${RUNID}
     labels:
-        git_repo: ${GIT_REPO}
+        git_repo: '${GIT_REPO}'
         git_sha: '${GIT_COMMIT}'
-        git_branch: ${GIT_BRANCH}
+        git_branch: '${GIT_BRANCH}'
 spec:
     ttlSecondsAfterFinished: 10
     backoffLimit: 0
@@ -14,20 +14,20 @@ spec:
             annotations:
                 cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
             labels:
-                git_repo: ${GIT_REPO}
+                git_repo: '${GIT_REPO}'
                 git_sha: '${GIT_COMMIT}'
-                git_branch: ${GIT_BRANCH}
+                git_branch: '${GIT_BRANCH}'
         spec:
-            serviceAccountName: ${KUBERNETES_SERVICEACCOUNT}
+            serviceAccountName: '${KUBERNETES_SERVICEACCOUNT}'
             restartPolicy: Never
             containers:
                 - name: driver
-                  image: ${IMAGE_TAG}
+                  image: '${IMAGE_TAG}'
                   env:
                       - name: GITHUB_TOKEN
                         valueFrom:
                             secretKeyRef:
-                                name: ${SECRET_NAME}
+                                name: '${SECRET_NAME}'
                                 key: GITHUB_TOKEN
                   resources:
                       limits:

--- a/add_me_to_your_PATH/driver.yaml.template
+++ b/add_me_to_your_PATH/driver.yaml.template
@@ -4,7 +4,7 @@ metadata:
     name: ${RUNID}
     labels:
         git_repo: ${GIT_REPO}
-        git_sha: ${GIT_COMMIT}
+        git_sha: '${GIT_COMMIT}'
         git_branch: ${GIT_BRANCH}
 spec:
     ttlSecondsAfterFinished: 10
@@ -15,7 +15,7 @@ spec:
                 cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
             labels:
                 git_repo: ${GIT_REPO}
-                git_sha: ${GIT_COMMIT}
+                git_sha: '${GIT_COMMIT}'
                 git_branch: ${GIT_BRANCH}
         spec:
             serviceAccountName: ${KUBERNETES_SERVICEACCOUNT}


### PR DESCRIPTION
YAML will interpret unquoted values that are entirely number characters as a number, and otherwise as a string. This can cause julia_pod to fail if a string is expected downstream and an interpolated value just so happens to contain only numbers. This quotes all the interpolated values that should be strings.