### PR TITLE
Bugfix: DOCKER copy

### DIFF
--- a/add_me_to_your_PATH/Dockerfile.template
+++ b/add_me_to_your_PATH/Dockerfile.template
@@ -121,7 +121,7 @@ COPY src/ JuliaProject/src/
 RUN julia --project=/JuliaProject -e 'using Pkg; Pkg.build(); Pkg.precompile()'
 
 # copy over all other files without re-running precompile
-COPY * JuliaProject/
+COPY . JuliaProject/
 
 ENV JULIA_PROJECT @.
 

--- a/add_me_to_your_PATH/driver.yaml.template
+++ b/add_me_to_your_PATH/driver.yaml.template
@@ -3,9 +3,9 @@ kind: Job
 metadata:
     name: ${RUNID}
     labels:
-        git_repo: ${GIT_REPO}
+        git_repo: '${GIT_REPO}'
         git_sha: '${GIT_COMMIT}'
-        git_branch: ${GIT_BRANCH}
+        git_branch: '${GIT_BRANCH}'
 spec:
     ttlSecondsAfterFinished: 10
     backoffLimit: 0
@@ -14,20 +14,20 @@ spec:
             annotations:
                 cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
             labels:
-                git_repo: ${GIT_REPO}
+                git_repo: '${GIT_REPO}'
                 git_sha: '${GIT_COMMIT}'
-                git_branch: ${GIT_BRANCH}
+                git_branch: '${GIT_BRANCH}'
         spec:
-            serviceAccountName: ${KUBERNETES_SERVICEACCOUNT}
+            serviceAccountName: '${KUBERNETES_SERVICEACCOUNT}'
             restartPolicy: Never
             containers:
                 - name: driver
-                  image: ${IMAGE_TAG}
+                  image: '${IMAGE_TAG}'
                   env:
                       - name: GITHUB_TOKEN
                         valueFrom:
                             secretKeyRef:
-                                name: ${SECRET_NAME}
+                                name: '${SECRET_NAME}'
                                 key: GITHUB_TOKEN
                   resources:
                       limits:

--- a/add_me_to_your_PATH/driver.yaml.template
+++ b/add_me_to_your_PATH/driver.yaml.template
@@ -4,7 +4,7 @@ metadata:
     name: ${RUNID}
     labels:
         git_repo: ${GIT_REPO}
-        git_sha: ${GIT_COMMIT}
+        git_sha: '${GIT_COMMIT}'
         git_branch: ${GIT_BRANCH}
 spec:
     ttlSecondsAfterFinished: 10
@@ -15,7 +15,7 @@ spec:
                 cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
             labels:
                 git_repo: ${GIT_REPO}
-                git_sha: ${GIT_COMMIT}
+                git_sha: '${GIT_COMMIT}'
                 git_branch: ${GIT_BRANCH}
         spec:
             serviceAccountName: ${KUBERNETES_SERVICEACCOUNT}


### PR DESCRIPTION
Turns out using `*` makes a flat copy of files. We want to maintain the directory structure of the project, so we should use `.` instead. (Branched from my other PR, so that one should probably merge first).