### PR TITLE
fix: add trailing `/`

### DIFF
--- a/add_me_to_your_PATH/Dockerfile.template
+++ b/add_me_to_your_PATH/Dockerfile.template
@@ -86,7 +86,7 @@ RUN --mount=type=secret,id=github_token \
     fi
 RUN mkdir -p /root/.julia/config
 
-COPY *Project.toml *Manifest.toml /JuliaProject
+COPY *Project.toml *Manifest.toml /JuliaProject/
 
 # comment out if you don't have any `dev --local` deps
 COPY dev/ /JuliaProject/dev/


### PR DESCRIPTION
Docker linting in VSCode indicates that a trailing `/` should be used in the directory being copied to (when copying an entire directory