### PR TITLE
Allow user env variables to modify driver template

### DIFF
--- a/add_me_to_your_PATH/julia_pod
+++ b/add_me_to_your_PATH/julia_pod
@@ -144,7 +144,7 @@ echo "GITHUB_TOKEN=$([ -z ${GITHUB_TOKEN_FILE} ] || cat ${GITHUB_TOKEN_FILE})" |
 
 # substitute ENV vars into driver.yaml.template > driver.yaml for this run
 log "Generating $DRIVER_YAML" \
-    && env -i \
+    && env \
         IMAGE_TAG="$IMAGE_TAG" \
         RUNID="$RUNID" \
         KUBERNETES_SERVICEACCOUNT="$KUBERNETES_SERVICEACCOUNT" \


### PR DESCRIPTION
That way the user can add additional templated variables without needing to modify `julia_pod`. For example, I want to check in a template to a repo but make the GPU configurable by env variable.

I have a Julia launch script using `REPL.TerminalMenu` so I can ask the user if they want a GPU then fill the env variable then launch julia pod.

I'm no expect but I think removing `-i` here means we start with the inherited env, which will let any other env variables pass through. And in practice this seems to work.