### PR TITLE
better way to decide what deps go in the sysimage

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,25 +169,33 @@ The default `Dockerfile` used by `julia_pod` is set up to
 time it takes to `using MyProject` your project.
 
 The convention for inclusion into the sysimage is that any
-project dependency that is **pinned** included,
-unless it is blacklisted as a package known not to work with
-`PackageCompiler.jl`. To add the dependency `Example` to the
-sysimage, in a julia REPL `Pkg` mode, do `]pin Example`.
-Pinned packages show with a little ⚲ next to them when listed
-with `]status`.
+project dependency that is tracking a registered package is
+included, and a `Manifest.toml.julia_pod` copy of your
+`Manifest.toml` created.
 
-This convention came about because the package manager `Pkg.jl`
-is not aware of what dependencies are included in the sysimage
-(they are treated as un-versioned dependencies as though they
-were part of the Julia stdlib, and always take precedence over
-whatever dependencies `Pkg.jl` thinks it has added to the
-project). Pinning the packages that are included in the sysimage 
-ensures that the package versions used by `Pkg.jl` are fixed 
-and cannot be accidentally changed. Without pinning a user
-could change the version of a package via Pkg but find that they
-are still only using the version locked into the sysimage.
-This is why it was decided to use pinned packages to control
-what is built into the sysimage.
+If `Manifest.toml.julia_pod` exists (because of a previous
+call to `julia_pod`), only the intersection of
+your dependencies and the dependencies in
+`Manifest.toml.julia_pod` will be included in the sysimage.
+This is so that adding packages during a `julia_pod` or
+regular `julia` session against that project environment
+does not invalidate the cache docker uses to build the
+`julia_pod`'s docker image, so that subsequent `julia_pod`
+startup times are fast.
+
+If you want new packages to be added to the sysimage,
+just `rm Manifest.toml.julia_pod` before running `julia_pod`.
+
+To add packages to your `julia_pod` session without invalidating
+the docker cache, pass in the `preserve=all` option,
+which will not change versions of dependencies that are already
+present when resolving a version for and installing the new
+package, by doing `]add --preserve=all SomeNewPackage`.
+Also, do not do any `Pkg` operations that will change versions
+of existing packages, such as `]up`. Note that calling `]rm`
+to remove packages that have been added since the last
+modification to `Manifest.toml.julia_pod` shouldn't
+invalidate the docker cache.
 
 
 ##### notebooks

--- a/README.md
+++ b/README.md
@@ -170,21 +170,24 @@ time it takes to `using MyProject` your project.
 
 The convention for inclusion into the sysimage is that any
 project dependency that is tracking a registered package is
-included, and a `Manifest.toml.julia_pod` copy of your
-`Manifest.toml` created.
+included, and a `julia_pod/sysimage.packages` list of your
+the dependencies in your `Manifest.toml` created.
 
-If `Manifest.toml.julia_pod` exists (because of a previous
+If `julia_pod/sysimage.packages` exists (because of a previous
 call to `julia_pod`), only the intersection of
 your dependencies and the dependencies in
-`Manifest.toml.julia_pod` will be included in the sysimage.
+`julia_pod/sysimage.packages` will be included in the sysimage.
 This is so that adding packages during a `julia_pod` or
 regular `julia` session against that project environment
 does not invalidate the cache docker uses to build the
 `julia_pod`'s docker image, so that subsequent `julia_pod`
-startup times are fast.
+startup times are fast. Note that removing dependencies
+that are in an existing `julia_pod/sysimage.packages`
+will invalidate the docker build cache the first time
+they are removed, and subsequent builds will be fast.
 
 If you want new packages to be added to the sysimage,
-just `rm Manifest.toml.julia_pod` before running `julia_pod`.
+just `rm julia_pod/sysimage.packages` before running `julia_pod`.
 
 To add packages to your `julia_pod` session without invalidating
 the docker cache, pass in the `preserve=all` option,
@@ -192,10 +195,7 @@ which will not change versions of dependencies that are already
 present when resolving a version for and installing the new
 package, by doing `]add --preserve=all SomeNewPackage`.
 Also, do not do any `Pkg` operations that will change versions
-of existing packages, such as `]up`. Note that calling `]rm`
-to remove packages that have been added since the last
-modification to `Manifest.toml.julia_pod` shouldn't
-invalidate the docker cache.
+of existing packages, such as `]up`.
 
 
 ##### notebooks

--- a/add_me_to_your_PATH/Dockerfile.template
+++ b/add_me_to_your_PATH/Dockerfile.template
@@ -5,7 +5,7 @@ ARG CUDA_VERSION
 
 FROM julia:${JULIA_VERSION}-buster as pinned-extractor
 
-COPY Project.toml Manifest.toml Manifest.toml.julia_pod .
+COPY Project.toml Manifest.toml ./julia_pod/sysimage.packages .
 
 # Remove all packages that are not pinned recursively from the manifest
 # (stdlibs count as pinned)
@@ -14,7 +14,7 @@ RUN julia --project=. -e 'using Pkg;\
                                           if !p.is_tracking_registry]; \
                           registered = [p.name for p in values(Pkg.dependencies()) \
                                         if p.is_tracking_registry]; \
-                          previous = [p.name for p in values(Pkg.Types.read_manifest("Manifest.toml.julia_pod"))]; \
+                          previous = readlines("sysimage.packages"); \
                           rm_deps = union(unregistered, setdiff(registered, previous)); \
                           println("removing $rm_deps"); sleep(1); \
                           isempty(rm_deps) || Pkg.rm(rm_deps; mode=Pkg.PKGMODE_MANIFEST); \
@@ -60,9 +60,13 @@ FROM base as sysimage-image
 # Install system dependencies needed to instantiate the environment and build
 # sysimage. Based on Docker's best practices w.r.t. apt-get:
 # https://docs.docker.com/develop/develop-images/dockerfile_best-practices/
-RUN apt-get update && apt-get install -y \
-    gcc \
-    && rm -rf /var/lib/apt/lists/*
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A4B469963BF863CC
+
+RUN apt-get update && \
+    apt-get install -y gcc && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN git clone --recurse-submodules -j8 https://github.com/julia-vscode/julia-vscode.git /julia-vscode
 
 # Instantiate the Julia project environment
 COPY --from=pinned-extractor *Project.toml *Manifest.toml /JuliaProject/
@@ -70,7 +74,7 @@ COPY --from=pinned-extractor *Project.toml *Manifest.toml /JuliaProject/
 RUN --mount=type=secret,id=github_token \
     julia --project=/JuliaProject -e 'using Pkg; Pkg.Registry.update(); Pkg.instantiate(); Pkg.build(); Pkg.precompile()'
 
-COPY sysimage.jl /JuliaProject/sysimage.jl
+COPY ./julia_pod/sysimage.jl /JuliaProject/sysimage.jl
 RUN --mount=type=secret,id=github_token \
     julia --project=/JuliaProject -e 'include("/JuliaProject/sysimage.jl")'
 
@@ -138,8 +142,6 @@ ENV JULIA_PROJECT @.
 
 WORKDIR /JuliaProject
 
-# start julia after repl history gets a chance to sync; is there a better way??
-RUN mkdir -p /root/.julia/config
-RUN echo 'n=8; sleep(n); println("done waiting $n secs for logs/repl_history.jl to sync...")' >> /root/.julia/config/startup.jl
+COPY julia_pod/startup.jl /root/.julia/config/startup.jl
 
 CMD julia

--- a/add_me_to_your_PATH/Dockerfile.template
+++ b/add_me_to_your_PATH/Dockerfile.template
@@ -5,15 +5,24 @@ ARG CUDA_VERSION
 
 FROM julia:${JULIA_VERSION}-buster as pinned-extractor
 
-COPY *Project.toml *Manifest.toml .
+COPY Project.toml Manifest.toml Manifest.toml.julia_pod .
 
 # Remove all packages that are not pinned recursively from the manifest
 # (stdlibs count as pinned)
 RUN julia --project=. -e 'using Pkg;\
-                          unpinned = [p.name for p in values(Pkg.dependencies()) \
-                                      if p.is_direct_dep && !p.is_pinned && \
-                                      p.name ∉ values(Pkg.Types.stdlibs())]; \
-                          isempty(unpinned) || Pkg.rm(unpinned; mode=Pkg.PKGMODE_MANIFEST)'
+                          unregistered = [p.name for p in values(Pkg.dependencies()) \
+                                          if !p.is_tracking_registry]; \
+                          registered = [p.name for p in values(Pkg.dependencies()) \
+                                        if p.is_tracking_registry]; \
+                          previous = [p.name for p in values(Pkg.Types.read_manifest("Manifest.toml.julia_pod"))]; \
+                          rm_deps = union(unregistered, setdiff(registered, previous)); \
+                          println("removing $rm_deps"); sleep(1); \
+                          isempty(rm_deps) || Pkg.rm(rm_deps; mode=Pkg.PKGMODE_MANIFEST); \
+                          direct = [p.name for p in values(Pkg.dependencies()) \
+                                          if !p.is_direct_dep]; \
+                          intersect!(rm_deps, direct); \
+                          isempty(rm_deps) || Pkg.rm(rm_deps; mode=Pkg.PKGMODE_PROJECT); \
+                          println(filter(contains(Regex(join(rm_deps, "|"))), readlines("Project.toml")))'
 
 FROM julia:${JULIA_VERSION}-buster as julia-base
 

--- a/add_me_to_your_PATH/Dockerfile.template
+++ b/add_me_to_your_PATH/Dockerfile.template
@@ -59,13 +59,11 @@ FROM base as sysimage-image
 # Install system dependencies needed to instantiate the environment and build
 # sysimage. Based on Docker's best practices w.r.t. apt-get:
 # https://docs.docker.com/develop/develop-images/dockerfile_best-practices/
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A4B469963BF863CC
 
 RUN apt-get update && \
     apt-get install -y gcc && \
     rm -rf /var/lib/apt/lists/*
 
-RUN git clone --recurse-submodules -j8 https://github.com/julia-vscode/julia-vscode.git /julia-vscode
 
 # Instantiate the Julia project environment
 COPY --from=sysimage-project *Project.toml *Manifest.toml /JuliaProject/

--- a/add_me_to_your_PATH/Dockerfile.template
+++ b/add_me_to_your_PATH/Dockerfile.template
@@ -3,11 +3,10 @@ ARG CUDA_VERSION
 
 # Extract Project.toml with pinned deps only + corresponding Manifest.toml
 
-FROM julia:${JULIA_VERSION}-buster as pinned-extractor
+FROM julia:${JULIA_VERSION}-buster as sysimage-project
 
 COPY Project.toml Manifest.toml ./julia_pod/sysimage.packages .
 
-# Remove all packages that are not pinned recursively from the manifest
 # (stdlibs count as pinned)
 RUN julia --project=. -e 'using Pkg;\
                           unregistered = [p.name for p in values(Pkg.dependencies()) \
@@ -16,7 +15,7 @@ RUN julia --project=. -e 'using Pkg;\
                                         if p.is_tracking_registry]; \
                           previous = readlines("sysimage.packages"); \
                           rm_deps = union(unregistered, setdiff(registered, previous)); \
-                          println("removing $rm_deps"); sleep(1); \
+                          println("removing $rm_deps"); \
                           isempty(rm_deps) || Pkg.rm(rm_deps; mode=Pkg.PKGMODE_MANIFEST); \
                           direct = [p.name for p in values(Pkg.dependencies()) \
                                           if !p.is_direct_dep]; \
@@ -69,7 +68,7 @@ RUN apt-get update && \
 RUN git clone --recurse-submodules -j8 https://github.com/julia-vscode/julia-vscode.git /julia-vscode
 
 # Instantiate the Julia project environment
-COPY --from=pinned-extractor *Project.toml *Manifest.toml /JuliaProject/
+COPY --from=sysimage-project *Project.toml *Manifest.toml /JuliaProject/
 
 RUN --mount=type=secret,id=github_token \
     julia --project=/JuliaProject -e 'using Pkg; Pkg.Registry.update(); Pkg.instantiate(); Pkg.build(); Pkg.precompile()'

--- a/add_me_to_your_PATH/build_image
+++ b/add_me_to_your_PATH/build_image
@@ -74,6 +74,7 @@ fi
 [[ -f julia_pod/sysimage.packages ]] || {
     warn "!!! no julia_pod/sysimage.packages found in ${PWD}, generating list of packages to include into sysimage from Manifest.toml"
     mkdir -p julia_pod
+    # this regex should work for both old and new Manifest.toml formats
     grep -o '\[\[.*\]\]' Manifest.toml | sed -r 's/\[\[(deps\.)?(.*)\]\]/\2/' > julia_pod/sysimage.packages
 }
 

--- a/add_me_to_your_PATH/build_image
+++ b/add_me_to_your_PATH/build_image
@@ -59,14 +59,22 @@ fi
     cp "${SCRIPT_DIR}/Dockerfile.template" Dockerfile
 }
 
-[[ -f sysimage.jl ]] || {
+[[ -f julia_pod/sysimage.jl ]] || {
     warn "!!! no sysimage.jl found in ${PWD}, copying ${SCRIPT_DIR}/sysimage.jl"
-    cp "${SCRIPT_DIR}/sysimage.jl" .
+    mkdir -p julia_pod
+    cp "${SCRIPT_DIR}/sysimage.jl" julia_pod
 }
 
-[[ -f Manifest.toml.julia_pod ]] || {
-    warn "!!! no Manifest.toml.julia_pod found in ${PWD}, copying Manifest.toml"
-    cp Manifest.toml Manifest.toml.julia_pod
+[[ -f julia_pod/startup.jl ]] || {
+    warn "!!! no startup.jl found in ${PWD}, copying ${SCRIPT_DIR}/startup.jl"
+    mkdir -p julia_pod
+    cp "${SCRIPT_DIR}/startup.jl" julia_pod
+}
+
+[[ -f julia_pod/sysimage.packages ]] || {
+    warn "!!! no julia_pod/sysimage.packages found in ${PWD}, generating list of packages to include into sysimage from Manifest.toml"
+    mkdir -p julia_pod
+    grep -o '\[\[.*\]\]' Manifest.toml | sed -r 's/\[\[(deps\.)?(.*)\]\]/\2/' > julia_pod/sysimage.packages
 }
 
 [[ -z "${JULIA_VERSION}" ]] && {

--- a/add_me_to_your_PATH/build_image
+++ b/add_me_to_your_PATH/build_image
@@ -64,8 +64,13 @@ fi
     cp "${SCRIPT_DIR}/sysimage.jl" .
 }
 
+[[ -f Manifest.toml.julia_pod ]] || {
+    warn "!!! no Manifest.toml.julia_pod found in ${PWD}, copying Manifest.toml"
+    cp Manifest.toml Manifest.toml.julia_pod
+}
+
 [[ -z "${JULIA_VERSION}" ]] && {
-    JULIA_VERSION=1.6
+    JULIA_VERSION=1.7
     log "JULIA_VERSION environment variable not set, defaulting to ${JULIA_VERSION}"
 }
 

--- a/add_me_to_your_PATH/julia_pod
+++ b/add_me_to_your_PATH/julia_pod
@@ -125,7 +125,7 @@ DRIVER_YAML="driver-${RUNID}.yaml"
 
 # if `julia_pod` was called with args, replace values in `driver.yaml`
 [[ -n "${JULIA_COMMAND}" ]] || {
-    JULIA_COMMAND='"julia"'
+    JULIA_COMMAND='"julia", "--startup-file=yes"'
 }
 if [ -n "${args}" ]; then
     # user passed in some julia code to run

--- a/add_me_to_your_PATH/startup.jl
+++ b/add_me_to_your_PATH/startup.jl
@@ -1,0 +1,14 @@
+@info "Running startup.jl"
+
+# start julia after repl history gets a chance to sync; is there a better way??
+n=8
+sleep(n)
+@info "done waiting $n secs for logs/repl_history.jl to sync..."
+
+# pushfirst!(LOAD_PATH, raw"/julia-vscode/scripts/packages")
+# using VSCodeServer
+# popfirst!(LOAD_PATH)
+# VSCodeServer.serve(4242,
+#                    is_dev = "DEBUG_MODE=true" in Base.ARGS,
+#                    crashreporting_pipename = raw"/tmp/vsc-jl-cr-b7089624-d6ca-4a6f-8942-563942f32a32")
+


### PR DESCRIPTION
This should result in fewer sysimage builds during docker builds, which is by far the longest build step generally.

Instead of basing the subset of deps included in the sysimage off of pinned packages, this:

*   includes all deps that track a registry
*   saves a ~`Manifest.toml.julia_pod`~ `julia_pod/sysimage.packages` listing dependencies to possibly include in the sysimage, and use it in a way that allows for packages to be added without invalidating the cached sysimage layer.

The rationale for this change is that:

*   managing long lists of pinned deps is cumbersome
*   pinned direct deps do not protect transitive deps from changing versions, even if they are pinned by hand in the Manifest
*   one most often wants to add all deps to the sysimage anyway, minus deps one is hacking on, which are generally deps that track a path or a repo.
*   the docker build cache was being invalidate too often

**Edit:**
This also defines and makes use of a `startup.jl` file, which gets copied to `.julia/config/startup.jl` in the pod,
and saves the `sysimage.jl` and `startup.jl` files to a new local `julia_pod/` folder alongside `julia_pod/sysimage.packages`, for hygene.

closes #37