### PR TITLE
shell `if [` uses `=` not `==` for comparison

### DIFF
--- a/add_me_to_your_PATH/Dockerfile.template
+++ b/add_me_to_your_PATH/Dockerfile.template
@@ -83,7 +83,7 @@ FROM sysimage-image as precompile-image
 # install Revise and PProf, even if not a dep of project
 ARG ADD_UTILS="true"
 RUN --mount=type=secret,id=github_token \
-    if [ "$ADD_UTILS" == "true" ]; then \
+    if [ "$ADD_UTILS" = "true" ]; then \
         julia -e 'using Pkg; Pkg.add("Revise"); Pkg.add("PProf"); Pkg.instantiate()'; \
     fi
 RUN mkdir -p /root/.julia/config


### PR DESCRIPTION
Currently Revise and PProf are never installed, because the `if [ "$ADD_UTILS" == true ]` is an error in sh (needs to be `=` with single `[`, adn `[[` are not available in sh where this step is happening).