### PR TITLE
`mv Dockerfile driver* julia_pod/.`

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ as `-e '...'`; this is achieved by appending `-e '...'` to the
 By default the julia project root and `~/.julia/logs` dirs are 
 synced, even when run with a julia command as arg. To not sync,
 pass in `julia_pod --no-sync [...]`; this will just copy whatever
-the `Dockerfile` has indicated into the docker image build,
+the `julia_pod/Dockerfile` has indicated into the docker image build,
 by default `src/`, `dev/`, `Project.toml` and `Manifest.toml`,
 but not sync your project folder with the container while 
 it is running.
@@ -91,9 +91,9 @@ project, push it to ECR, and run it in the cluster, dropping you
 into a julia REPL.
 
 `--image` lets you pass in a publicly available image name or ECR image 
-tag. If absent, `julia_pod` will look for a `Dockerfile` in your current
-folder to build an image from, and if that's not present it'll use
-`add_me_to_your_PATH/Dockerfile.template`. Note that
+tag. If absent, `julia_pod` will look for a `julia_pod/Dockerfile`
+from your current folder to build an image from, and if that's not
+present it'll use `add_me_to_your_PATH/Dockerfile.template`. Note that
 custom `Dockerfile`s need to be structured
 with the same build stages as `add_me_to_your_PATH/Dockerfile.template`.
 
@@ -126,7 +126,7 @@ and then `build_image` to build one. For this:
   repositories, you can provide that secret by storing it in a file and
   specifying the path in the environment variable: `GITHUB_TOKEN_FILE`.
 
-If you do not have a `Dockerfile` or `driver.yaml.template`
+If you do not have a `julia_pod/Dockerfile` or `driver.yaml.template`
 in your julia project root dir, default versions of these will be
 copied over. At this point, you may want to take a look at both of
 these files and edit them, remembering that `driver.yaml.template`

--- a/README.md
+++ b/README.md
@@ -169,25 +169,33 @@ The default `Dockerfile` used by `julia_pod` is set up to
 time it takes to `using MyProject` your project.
 
 The convention for inclusion into the sysimage is that any
-project dependency that is **pinned** included,
-unless it is blacklisted as a package known not to work with
-`PackageCompiler.jl`. To add the dependency `Example` to the
-sysimage, in a julia REPL `Pkg` mode, do `]pin Example`.
-Pinned packages show with a little ⚲ next to them when listed
-with `]status`.
+project dependency that is tracking a registered package is
+included, and a `Manifest.toml.julia_pod` copy of your
+`Manifest.toml` created.
 
-This convention came about because the package manager `Pkg.jl`
-is not aware of what dependencies are included in the sysimage
-(they are treated as un-versioned dependencies as though they
-were part of the Julia stdlib, and always take precedence over
-whatever dependencies `Pkg.jl` thinks it has added to the
-project). Pinning the packages that are included in the sysimage 
-ensures that the package versions used by `Pkg.jl` are fixed 
-and cannot be accidentally changed. Without pinning a user
-could change the version of a package via Pkg but find that they
-are still only using the version locked into the sysimage.
-This is why it was decided to use pinned packages to control
-what is built into the sysimage.
+If `Manifest.toml.julia_pod` exists (because of a previous
+call to `julia_pod`), only the intersection of
+your dependencies and the dependencies in
+`Manifest.toml.julia_pod` will be included in the sysimage.
+This is so that adding packages during a `julia_pod` or
+regular `julia` session against that project environment
+does not invalidate the cache docker uses to build the
+`julia_pod`'s docker image, so that subsequent `julia_pod`
+startup times are fast.
+
+If you want new packages to be added to the sysimage,
+just `rm Manifest.toml.julia_pod` before running `julia_pod`.
+
+To add packages to your `julia_pod` session without invalidating
+the docker cache, pass in the `preserve=all` option,
+which will not change versions of dependencies that are already
+present when resolving a version for and installing the new
+package, by doing `]add --preserve=all SomeNewPackage`.
+Also, do not do any `Pkg` operations that will change versions
+of existing packages, such as `]up`. Note that calling `]rm`
+to remove packages that have been added since the last
+modification to `Manifest.toml.julia_pod` shouldn't
+invalidate the docker cache.
 
 
 ##### notebooks

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ run jobs by doing:
 as `julia_pod`, except the single arg is passed to julia
 as `-e '...'`; this is achieved by appending `-e '...'` to the
 `containers.command` value in the pod spec defined in
-`driver.yaml.template`.
+`julia_pod/driver.yaml.template`.
 
 By default the julia project root and `~/.julia/logs` dirs are 
 synced, even when run with a julia command as arg. To not sync,
@@ -114,7 +114,7 @@ based on the git repo and branch names.
 If you do not set this, it will default to `$PROJECT_NAME`.
 
 `--driver-yaml-template=...` lets you specify a k8s pod spec file other than
-the default `driver.yaml.template`.
+the default `julia_pod/driver.yaml.template`.
 
 If no `--image=...` is passed in, `julia_pod` will call `accounts.sh`
 and then `build_image` to build one. For this:
@@ -129,10 +129,10 @@ and then `build_image` to build one. For this:
   repositories, you can provide that secret by storing it in a file and
   specifying the path in the environment variable: `GITHUB_TOKEN_FILE`.
 
-If you do not have a `julia_pod/Dockerfile` or `driver.yaml.template`
+If you do not have a `julia_pod/Dockerfile` or `julia_pod/driver.yaml.template`
 in your julia project root dir, default versions of these will be
 copied over. At this point, you may want to take a look at both of
-these files and edit them, remembering that `driver.yaml.template`
+these files and edit them, remembering that `julia_pod/driver.yaml.template`
 has comments indicating what not to touch;
 in particular, it has `$ALLCAPS` strings that will be replaced
 with runtime values when running `julia_pod`.
@@ -209,7 +209,7 @@ Pluto and ijulia notebooks work from `julia_pod` sessions, as long as:
 - you are port-forwarding from your pet instance to the pod by doing
 
 ```bash
-driver=`ls driver-*.yaml | tail -n 1 | cut -d '.' -f 1`
+driver=`ls julia_pod/driver-*.yaml | tail -n 1 | cut -d '.' -f 1`
 kubectl port-forward pods/$driver 1234:1234 -n project-foo
 ```
 
@@ -225,9 +225,9 @@ traffic will then be passing through both port forwarding hops.)
 ### what it does
 
 `julia_pod` will:
-- copy over `add_me_to_your_PATH/{Dockerfile.template,sysimage.jl,driver.yaml.template}`
-  to the project root dir if those files are absent
-- ask you if you want to `$EDITOR driver.yaml.template`, to for example
+- copy over `add_me_to_your_PATH/{Dockerfile.template,sysimage.jl,driver.yaml.template,startup.jl}`
+  to `julia_pod/` in the project root dir if those files are absent
+- ask you if you want to `$EDITOR julia_pod/driver.yaml.template`, to for example
   request a GPU or other resources
 - compute a descriptive docker image tag of the form
 `${GIT_REPO}_${GIT_BRANCH}_commit-${GIT_COMMIT}_sha1-${PROJECT_ROOTDIR}`

--- a/README.md
+++ b/README.md
@@ -170,21 +170,24 @@ time it takes to `using MyProject` your project.
 
 The convention for inclusion into the sysimage is that any
 project dependency that is tracking a registered package is
-included, and a `Manifest.toml.julia_pod` copy of your
-`Manifest.toml` created.
+included, and a `julia_pod/sysimage.packages` list of your
+the dependencies in your `Manifest.toml` created.
 
-If `Manifest.toml.julia_pod` exists (because of a previous
+If `julia_pod/sysimage.packages` exists (because of a previous
 call to `julia_pod`), only the intersection of
 your dependencies and the dependencies in
-`Manifest.toml.julia_pod` will be included in the sysimage.
+`julia_pod/sysimage.packages` will be included in the sysimage.
 This is so that adding packages during a `julia_pod` or
 regular `julia` session against that project environment
 does not invalidate the cache docker uses to build the
 `julia_pod`'s docker image, so that subsequent `julia_pod`
-startup times are fast.
+startup times are fast. Note that removing dependencies
+that are in an existing `julia_pod/sysimage.packages`
+will invalidate the docker build cache the first time
+they are removed, and subsequent builds will be fast.
 
 If you want new packages to be added to the sysimage,
-just `rm Manifest.toml.julia_pod` before running `julia_pod`.
+just `rm julia_pod/sysimage.packages` before running `julia_pod`.
 
 To add packages to your `julia_pod` session without invalidating
 the docker cache, pass in the `preserve=all` option,
@@ -192,10 +195,7 @@ which will not change versions of dependencies that are already
 present when resolving a version for and installing the new
 package, by doing `]add --preserve=all SomeNewPackage`.
 Also, do not do any `Pkg` operations that will change versions
-of existing packages, such as `]up`. Note that calling `]rm`
-to remove packages that have been added since the last
-modification to `Manifest.toml.julia_pod` shouldn't
-invalidate the docker cache.
+of existing packages, such as `]up`.
 
 
 ##### notebooks

--- a/add_me_to_your_PATH/Dockerfile.template
+++ b/add_me_to_your_PATH/Dockerfile.template
@@ -5,7 +5,7 @@ ARG CUDA_VERSION
 
 FROM julia:${JULIA_VERSION}-buster as pinned-extractor
 
-COPY Project.toml Manifest.toml Manifest.toml.julia_pod .
+COPY Project.toml Manifest.toml ./julia_pod/sysimage.packages .
 
 # Remove all packages that are not pinned recursively from the manifest
 # (stdlibs count as pinned)
@@ -14,7 +14,7 @@ RUN julia --project=. -e 'using Pkg;\
                                           if !p.is_tracking_registry]; \
                           registered = [p.name for p in values(Pkg.dependencies()) \
                                         if p.is_tracking_registry]; \
-                          previous = [p.name for p in values(Pkg.Types.read_manifest("Manifest.toml.julia_pod"))]; \
+                          previous = readlines("sysimage.packages"); \
                           rm_deps = union(unregistered, setdiff(registered, previous)); \
                           println("removing $rm_deps"); sleep(1); \
                           isempty(rm_deps) || Pkg.rm(rm_deps; mode=Pkg.PKGMODE_MANIFEST); \
@@ -60,9 +60,13 @@ FROM base as sysimage-image
 # Install system dependencies needed to instantiate the environment and build
 # sysimage. Based on Docker's best practices w.r.t. apt-get:
 # https://docs.docker.com/develop/develop-images/dockerfile_best-practices/
-RUN apt-get update && apt-get install -y \
-    gcc \
-    && rm -rf /var/lib/apt/lists/*
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A4B469963BF863CC
+
+RUN apt-get update && \
+    apt-get install -y gcc && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN git clone --recurse-submodules -j8 https://github.com/julia-vscode/julia-vscode.git /julia-vscode
 
 # Instantiate the Julia project environment
 COPY --from=pinned-extractor *Project.toml *Manifest.toml /JuliaProject/
@@ -70,7 +74,7 @@ COPY --from=pinned-extractor *Project.toml *Manifest.toml /JuliaProject/
 RUN --mount=type=secret,id=github_token \
     julia --project=/JuliaProject -e 'using Pkg; Pkg.Registry.update(); Pkg.instantiate(); Pkg.build(); Pkg.precompile()'
 
-COPY sysimage.jl /JuliaProject/sysimage.jl
+COPY ./julia_pod/sysimage.jl /JuliaProject/sysimage.jl
 RUN --mount=type=secret,id=github_token \
     julia --project=/JuliaProject -e 'include("/JuliaProject/sysimage.jl")'
 
@@ -138,8 +142,6 @@ ENV JULIA_PROJECT @.
 
 WORKDIR /JuliaProject
 
-# start julia after repl history gets a chance to sync; is there a better way??
-RUN mkdir -p /root/.julia/config
-RUN echo 'n=8; sleep(n); println("done waiting $n secs for logs/repl_history.jl to sync...")' >> /root/.julia/config/startup.jl
+COPY julia_pod/startup.jl /root/.julia/config/startup.jl
 
 CMD julia

--- a/add_me_to_your_PATH/Dockerfile.template
+++ b/add_me_to_your_PATH/Dockerfile.template
@@ -5,15 +5,24 @@ ARG CUDA_VERSION
 
 FROM julia:${JULIA_VERSION}-buster as pinned-extractor
 
-COPY *Project.toml *Manifest.toml .
+COPY Project.toml Manifest.toml Manifest.toml.julia_pod .
 
 # Remove all packages that are not pinned recursively from the manifest
 # (stdlibs count as pinned)
 RUN julia --project=. -e 'using Pkg;\
-                          unpinned = [p.name for p in values(Pkg.dependencies()) \
-                                      if p.is_direct_dep && !p.is_pinned && \
-                                      p.name ∉ values(Pkg.Types.stdlibs())]; \
-                          isempty(unpinned) || Pkg.rm(unpinned; mode=Pkg.PKGMODE_MANIFEST)'
+                          unregistered = [p.name for p in values(Pkg.dependencies()) \
+                                          if !p.is_tracking_registry]; \
+                          registered = [p.name for p in values(Pkg.dependencies()) \
+                                        if p.is_tracking_registry]; \
+                          previous = [p.name for p in values(Pkg.Types.read_manifest("Manifest.toml.julia_pod"))]; \
+                          rm_deps = union(unregistered, setdiff(registered, previous)); \
+                          println("removing $rm_deps"); sleep(1); \
+                          isempty(rm_deps) || Pkg.rm(rm_deps; mode=Pkg.PKGMODE_MANIFEST); \
+                          direct = [p.name for p in values(Pkg.dependencies()) \
+                                          if !p.is_direct_dep]; \
+                          intersect!(rm_deps, direct); \
+                          isempty(rm_deps) || Pkg.rm(rm_deps; mode=Pkg.PKGMODE_PROJECT); \
+                          println(filter(contains(Regex(join(rm_deps, "|"))), readlines("Project.toml")))'
 
 FROM julia:${JULIA_VERSION}-buster as julia-base
 

--- a/add_me_to_your_PATH/Dockerfile.template
+++ b/add_me_to_your_PATH/Dockerfile.template
@@ -3,11 +3,10 @@ ARG CUDA_VERSION
 
 # Extract Project.toml with pinned deps only + corresponding Manifest.toml
 
-FROM julia:${JULIA_VERSION}-buster as pinned-extractor
+FROM julia:${JULIA_VERSION}-buster as sysimage-project
 
 COPY Project.toml Manifest.toml ./julia_pod/sysimage.packages .
 
-# Remove all packages that are not pinned recursively from the manifest
 # (stdlibs count as pinned)
 RUN julia --project=. -e 'using Pkg;\
                           unregistered = [p.name for p in values(Pkg.dependencies()) \
@@ -16,7 +15,7 @@ RUN julia --project=. -e 'using Pkg;\
                                         if p.is_tracking_registry]; \
                           previous = readlines("sysimage.packages"); \
                           rm_deps = union(unregistered, setdiff(registered, previous)); \
-                          println("removing $rm_deps"); sleep(1); \
+                          println("removing $rm_deps"); \
                           isempty(rm_deps) || Pkg.rm(rm_deps; mode=Pkg.PKGMODE_MANIFEST); \
                           direct = [p.name for p in values(Pkg.dependencies()) \
                                           if !p.is_direct_dep]; \
@@ -69,7 +68,7 @@ RUN apt-get update && \
 RUN git clone --recurse-submodules -j8 https://github.com/julia-vscode/julia-vscode.git /julia-vscode
 
 # Instantiate the Julia project environment
-COPY --from=pinned-extractor *Project.toml *Manifest.toml /JuliaProject/
+COPY --from=sysimage-project *Project.toml *Manifest.toml /JuliaProject/
 
 RUN --mount=type=secret,id=github_token \
     julia --project=/JuliaProject -e 'using Pkg; Pkg.Registry.update(); Pkg.instantiate(); Pkg.build(); Pkg.precompile()'

--- a/add_me_to_your_PATH/build_image
+++ b/add_me_to_your_PATH/build_image
@@ -59,14 +59,22 @@ fi
     cp "${SCRIPT_DIR}/Dockerfile.template" Dockerfile
 }
 
-[[ -f sysimage.jl ]] || {
+[[ -f julia_pod/sysimage.jl ]] || {
     warn "!!! no sysimage.jl found in ${PWD}, copying ${SCRIPT_DIR}/sysimage.jl"
-    cp "${SCRIPT_DIR}/sysimage.jl" .
+    mkdir -p julia_pod
+    cp "${SCRIPT_DIR}/sysimage.jl" julia_pod
 }
 
-[[ -f Manifest.toml.julia_pod ]] || {
-    warn "!!! no Manifest.toml.julia_pod found in ${PWD}, copying Manifest.toml"
-    cp Manifest.toml Manifest.toml.julia_pod
+[[ -f julia_pod/startup.jl ]] || {
+    warn "!!! no startup.jl found in ${PWD}, copying ${SCRIPT_DIR}/startup.jl"
+    mkdir -p julia_pod
+    cp "${SCRIPT_DIR}/startup.jl" julia_pod
+}
+
+[[ -f julia_pod/sysimage.packages ]] || {
+    warn "!!! no julia_pod/sysimage.packages found in ${PWD}, generating list of packages to include into sysimage from Manifest.toml"
+    mkdir -p julia_pod
+    grep -o '\[\[.*\]\]' Manifest.toml | sed -r 's/\[\[(deps\.)?(.*)\]\]/\2/' > julia_pod/sysimage.packages
 }
 
 [[ -z "${JULIA_VERSION}" ]] && {

--- a/add_me_to_your_PATH/build_image
+++ b/add_me_to_your_PATH/build_image
@@ -64,8 +64,13 @@ fi
     cp "${SCRIPT_DIR}/sysimage.jl" .
 }
 
+[[ -f Manifest.toml.julia_pod ]] || {
+    warn "!!! no Manifest.toml.julia_pod found in ${PWD}, copying Manifest.toml"
+    cp Manifest.toml Manifest.toml.julia_pod
+}
+
 [[ -z "${JULIA_VERSION}" ]] && {
-    JULIA_VERSION=1.6
+    JULIA_VERSION=1.7
     log "JULIA_VERSION environment variable not set, defaulting to ${JULIA_VERSION}"
 }
 

--- a/add_me_to_your_PATH/build_image
+++ b/add_me_to_your_PATH/build_image
@@ -54,9 +54,10 @@ fi
     bail "no src/ found in $PWD"
 }
 
-[[ -f Dockerfile ]] || {
-    warn "!!! no Dockerfile found in ${PWD}, copying ${SCRIPT_DIR}/Dockerfile.template"
-    cp "${SCRIPT_DIR}/Dockerfile.template" Dockerfile
+[[ -f julia_pod/Dockerfile ]] || {
+    warn "!!! no julia_pod/Dockerfile found in ${PWD}, copying ${SCRIPT_DIR}/Dockerfile.template"
+    mkdir -p julia_pod
+    cp "${SCRIPT_DIR}/Dockerfile.template" julia_pod/Dockerfile
 }
 
 [[ -f julia_pod/sysimage.jl ]] || {
@@ -112,7 +113,8 @@ log "building and pushing sysimage-image with ECR_TAG = $BASE_IMAGE_CACHE"
 
 
 
-docker buildx build --target base \
+docker buildx build -f julia_pod/Dockerfile \
+                    --target base \
                     --build-arg "JULIA_VERSION=$JULIA_VERSION" \
                     --build-arg "CUDA_VERSION=$CUDA_VERSION" \
                     --build-arg "BUILDKIT_INLINE_CACHE=1" \
@@ -122,7 +124,8 @@ docker buildx build --target base \
 
 log "building and pushing sysimage-image with ECR_TAG = $SYSIMAGE_IMAGE_CACHE"
 
-docker buildx build --target sysimage-image \
+docker buildx build -f julia_pod/Dockerfile \
+                    --target sysimage-image \
                     --build-arg "BUILDKIT_INLINE_CACHE=1" \
                     --build-arg "JULIA_VERSION=$JULIA_VERSION" \
                     --build-arg "CUDA_VERSION=$CUDA_VERSION" \
@@ -133,7 +136,8 @@ docker buildx build --target sysimage-image \
 
 log "building and loading precompile-image with TAG = $PRECOMPILE_IMAGE_CACHE"
 
-docker buildx build --target precompile-image \
+docker buildx build -f julia_pod/Dockerfile \
+                    --target precompile-image \
                     --build-arg "BUILDKIT_INLINE_CACHE=1" \
                     --build-arg "JULIA_VERSION=$JULIA_VERSION" \
                     --build-arg "CUDA_VERSION=$CUDA_VERSION" \
@@ -145,7 +149,8 @@ docker buildx build --target precompile-image \
 
 log "building and pushing image with ECR_TAG = $IMAGE_TAG"
 
-docker buildx build --build-arg "BUILDKIT_INLINE_CACHE=1" \
+docker buildx build -f julia_pod/Dockerfile \
+                    --build-arg "BUILDKIT_INLINE_CACHE=1" \
                     --build-arg "JULIA_VERSION=$JULIA_VERSION" \
                     --build-arg "CUDA_VERSION=$CUDA_VERSION" \
                     ${BUILD_ARGS[@]} \

--- a/add_me_to_your_PATH/julia_pod
+++ b/add_me_to_your_PATH/julia_pod
@@ -34,7 +34,7 @@ nargs="$#"
 
 BUILD_ARGS=""
 
-DRIVER_YAML_TEMPLATE="driver.yaml.template"
+DRIVER_YAML_TEMPLATE="julia_pod/driver.yaml.template"
 
 # parse args
 while [ -n "$*" ]; do
@@ -109,18 +109,18 @@ RUNID="$(echo $RUNID | sed -e 's/[^a-zA-Z0-9]\+/-/g')-$(date +%a%Hh%Mm%S)"
 RUNID="$(echo ${RUNID##*(-)} | tr '[:upper:]' '[:lower:]')"
 RUNID=${RUNID}-"$(openssl rand -hex 3)"
 
-DRIVER_YAML="driver-${RUNID}.yaml"
+DRIVER_YAML="julia_pod/driver-${RUNID}.yaml"
 
-# give user a chance to customize `driver.yaml.template` if not found in pwd
+# give user a chance to customize `julia_pod/driver.yaml.template` if not found in pwd
 [[ -f "${DRIVER_YAML_TEMPLATE}" ]] || {
-    if [[ "${DRIVER_YAML_TEMPLATE}" == "driver.yaml.template" ]]; then
-        warn "!!! no driver.yaml.template found in ${PWD}, copying ${SCRIPT_DIR}/driver.yaml.template"
-        cp "${SCRIPT_DIR}/driver.yaml.template" .
+    if [[ "${DRIVER_YAML_TEMPLATE}" == "julia_pod/driver.yaml.template" ]]; then
+        warn "!!! no julia_pod/driver.yaml.template found in ${PWD}, copying ${SCRIPT_DIR}/driver.yaml.template"
+        cp "${SCRIPT_DIR}/driver.yaml.template" julia_pod/.
         while true; do
-            read -p ">>> View/edit newly copied stock driver.yaml.template k8s pod spec before continuing? [yN] " yn
+            read -p ">>> View/edit newly copied stock julia_pod/driver.yaml.template k8s pod spec before continuing? [yN] " yn
             case $yn in
             [Yy]*)
-                $EDITOR driver.yaml.template
+                $EDITOR julia_pod/driver.yaml.template
                 break
                 ;;
             *) break ;;

--- a/add_me_to_your_PATH/julia_pod
+++ b/add_me_to_your_PATH/julia_pod
@@ -125,7 +125,7 @@ DRIVER_YAML="driver-${RUNID}.yaml"
 
 # if `julia_pod` was called with args, replace values in `driver.yaml`
 [[ -n "${JULIA_COMMAND}" ]] || {
-    JULIA_COMMAND='"julia"'
+    JULIA_COMMAND='"julia", "--startup-file=yes"'
 }
 if [ -n "${args}" ]; then
     # user passed in some julia code to run

--- a/add_me_to_your_PATH/startup.jl
+++ b/add_me_to_your_PATH/startup.jl
@@ -1,0 +1,14 @@
+@info "Running startup.jl"
+
+# start julia after repl history gets a chance to sync; is there a better way??
+n=8
+sleep(n)
+@info "done waiting $n secs for logs/repl_history.jl to sync..."
+
+# pushfirst!(LOAD_PATH, raw"/julia-vscode/scripts/packages")
+# using VSCodeServer
+# popfirst!(LOAD_PATH)
+# VSCodeServer.serve(4242,
+#                    is_dev = "DEBUG_MODE=true" in Base.ARGS,
+#                    crashreporting_pipename = raw"/tmp/vsc-jl-cr-b7089624-d6ca-4a6f-8942-563942f32a32")
+


### PR DESCRIPTION
This moves the `Dockerfile`, default `driver.yaml.template` and generated `driver-*.yaml` into the local `julia_pod/`, for sanity.

Now all local julia_pod-related files are tucked away in `julia_pod/`.