### PR TITLE
truncate RUNIDs to 44 chars before adding time and random hex

### DIFF
--- a/add_me_to_your_PATH/julia_pod
+++ b/add_me_to_your_PATH/julia_pod
@@ -105,7 +105,11 @@ fi
 
 # append day/time, both for podname quasi uniqueness and human-friendliness
 # sanitize to be valid dns entry
-RUNID="$(echo $RUNID | sed -e 's/[^a-zA-Z0-9]\+/-/g')-$(date +%a%Hh%Mm%S)"
+#
+# RUNID will be truncated to 63 - 12 - 7 = 44 characters to make room for these
+# suffixes while still staying within the 63 char limit on k8s names
+RUNID="$(echo $RUNID | cut -c 1-44 | sed -e 's/[^a-zA-Z0-9]\+/-/g')"
+RUNID="${RUNID}-$(date +%a%Hh%Mm%S)"
 RUNID="$(echo ${RUNID##*(-)} | tr '[:upper:]' '[:lower:]')"
 RUNID=${RUNID}-"$(openssl rand -hex 3)"
 

--- a/add_me_to_your_PATH/julia_pod
+++ b/add_me_to_your_PATH/julia_pod
@@ -108,7 +108,7 @@ fi
 #
 # RUNID will be truncated to 63 - 12 - 7 = 44 characters to make room for these
 # suffixes while still staying within the 63 char limit on k8s names
-RUNID="$(echo $RUNID | cut -c 1-44 | sed -e 's/[^a-zA-Z0-9]\+/-/g')"
+RUNID="$(echo $RUNID | sed -e 's/[^a-zA-Z0-9]\+/-/g' | cut -c 1-44)"
 RUNID="${RUNID}-$(date +%a%Hh%Mm%S)"
 RUNID="$(echo ${RUNID##*(-)} | tr '[:upper:]' '[:lower:]')"
 RUNID=${RUNID}-"$(openssl rand -hex 3)"


### PR DESCRIPTION
This PR is one possible fix for #50: before adding the datetime stamp (which adds 12 characters, `-dddHHhMMmSS`) and the random hex (7 characters, `-XXXXXX`), this truncates the RUNID to be at most 44 characters so that the job name will always be 63 characters or fewer (44 + 12 + 7).

IIUC, this should still be compatible with things like K8sClusterManagers.jl which use `generateName` since that does its own truncation.