### PR TITLE
Remove use of K8s secret to store GitHub PAT

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ vars for your cluster:
 
 To give your `julia_pod` access to private packages set the following ENV vars:
 - `PRIVATE_REGISTRY_URL` -- URL to the private Julia package registry
-- `GITHUB_TOKEN_FILE` -- Path to a file containing [Personal Access Token](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token) with "repo" scope access.
+- `GITHUB_TOKEN_FILE` -- Path to a file containing [Personal Access Token](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token) with "repo" scope access. The PAT will only be used to install private Julia packages during build of the Docker image and will not be available from within the container at runtime.
 
 Then just add `add_me_to_your_PATH/` to your path, or call
 `/path/to/add_me_to_your_PATH/julia_pod`.

--- a/add_me_to_your_PATH/Dockerfile.template
+++ b/add_me_to_your_PATH/Dockerfile.template
@@ -44,7 +44,7 @@ ENV PYTHON ""
 # Install github-token-helper to allow for private repo access via `docker build --secret id=github_token,src=token.txt ...`
 RUN curl -L https://raw.githubusercontent.com/beacon-biosignals/github-token-helper/v0.1.1/github-token-helper -o $HOME/.github-token-helper && \
     chmod +x $HOME/.github-token-helper && \
-    git config --global credential.https://github.com.helper "$HOME/.github-token-helper -f /run/secrets/github_token -e GITHUB_TOKEN"
+    git config --global credential.https://github.com.helper "$HOME/.github-token-helper -f /run/secrets/github_token"
 
 # Install the General registry and optionally a private registry
 ARG PRIVATE_REGISTRY_URL=""

--- a/add_me_to_your_PATH/driver.yaml.template
+++ b/add_me_to_your_PATH/driver.yaml.template
@@ -23,12 +23,6 @@ spec:
             containers:
                 - name: driver
                   image: '${IMAGE_TAG}'
-                  env:
-                      - name: GITHUB_TOKEN
-                        valueFrom:
-                            secretKeyRef:
-                                name: '${SECRET_NAME}'
-                                key: GITHUB_TOKEN
                   resources:
                       limits:
                           memory: 16Gi

--- a/add_me_to_your_PATH/julia_pod
+++ b/add_me_to_your_PATH/julia_pod
@@ -149,12 +149,6 @@ fi
 JULIA_COMMAND="[${JULIA_COMMAND}]"
 echo $JULIA_COMMAND
 
-# generate a k8s secret name
-SECRET_NAME=$(echo "${AWS_USER_ID}" | tr '[:upper:]' '[:lower:]' | sed -e 's/[^a-z0-9]\+/-/g')
-
-# pod will fail to start unless secret and key are present. When `GITHUB_TOKEN_FILE` isn't set this will be populated with ""
-echo "GITHUB_TOKEN=$([ -z ${GITHUB_TOKEN_FILE} ] || cat ${GITHUB_TOKEN_FILE})" | kubectl create secret generic $SECRET_NAME --save-config --dry-run=client --from-env-file=/dev/stdin -o yaml | kubectl apply -f -
-
 #GIT_INFO="${GIT_REPO}_${GIT_BRANCH}"
 
 # substitute ENV vars into driver.yaml.template > driver.yaml for this run
@@ -164,7 +158,6 @@ log "Generating $DRIVER_YAML" \
         RUNID="$RUNID" \
         KUBERNETES_SERVICEACCOUNT="$KUBERNETES_SERVICEACCOUNT" \
         JULIA_COMMAND="$JULIA_COMMAND" \
-        SECRET_NAME="$SECRET_NAME" \
         GIT_REPO="$GIT_REPO" \
         GIT_BRANCH="$GIT_BRANCH" \
         GIT_COMMIT="$GIT_COMMIT" \


### PR DESCRIPTION
The `julia_pod` feature to allow easy interactive adding of private packages uses a K8s secret to store the user's GitHub PAT. The K8s secret could be read by anyone with access to the namespace which has the potential to leak the GitHub PAT to malicious actors. This PR removes this feature but preserves the ability to use private Julia packages during the image build.

Supersedes: #56 