### PR TITLE
Fix inability to add packages interactively

### DIFF
--- a/add_me_to_your_PATH/Dockerfile.template
+++ b/add_me_to_your_PATH/Dockerfile.template
@@ -42,7 +42,7 @@ ENV CUDA_HOME /usr/local/cuda
 ENV PYTHON ""
 
 # Install github-token-helper to allow for private repo access via `docker build --secret id=github_token,src=token.txt ...`
-RUN curl -L https://raw.githubusercontent.com/beacon-biosignals/github-token-helper/v0.1.1/github-token-helper -o $HOME/.github-token-helper && \
+RUN curl -L https://raw.githubusercontent.com/beacon-biosignals/github-token-helper/v0.1.2/github-token-helper -o $HOME/.github-token-helper && \
     chmod +x $HOME/.github-token-helper && \
     git config --global credential.https://github.com.helper "$HOME/.github-token-helper -f /run/secrets/github_token"
 


### PR DESCRIPTION
Follow up to #60. Uses a newer version of `github-token-helper` which doesn't result in a failure when interactively adding package when a private registry is present:
```
(JuliaProject) pkg> add LibPQ
    Updating registry at `~/.julia/registries/Private`
    Updating git-repo `https://github.com/example/PrivateRegistry`
Specified GitHub token file does not exist: /run/secrets/github_token
ERROR: IOError: write: broken pipe (EPIPE)
Stacktrace:
  [1] uv_write(s::Base.PipeEndpoint, p::Ptr{UInt8}, n::UInt64)
    @ Base ./stream.jl:1010
  [2] unsafe_write(s::Base.PipeEndpoint, p::Ptr{UInt8}, n::UInt64)
    @ Base ./stream.jl:1064
  [3] unsafe_write(io::Base.Process, p::Ptr{UInt8}, nb::UInt64)
    @ Base ./io.jl:362
  [4] write
    @ ./strings/io.jl:244 [inlined]
...
```
With this change:
```
(JuliaProject) pkg> add LibPQ
    Updating registry at `~/.julia/registries/Private`
    Updating git-repo `https://github.com/example/PrivateRegistry`
Specified GitHub token(s) could not be found
Username for 'https://github.com':
```
The "Specified GitHub token(s) could not be found" warning is from the `github-token-helper` and should probably be dropped but it's fine to have for now.