### PR TITLE
preserve all

### DIFF
--- a/add_me_to_your_PATH/Dockerfile.template
+++ b/add_me_to_your_PATH/Dockerfile.template
@@ -93,7 +93,7 @@ FROM sysimage-image as precompile-image
 ARG ADD_UTILS="true"
 RUN --mount=type=secret,id=github_token \
     if [ "$ADD_UTILS" = "true" ]; then \
-        julia -e 'using Pkg; Pkg.add("Revise"); Pkg.add("PProf"); Pkg.instantiate()'; \
+        julia -e 'using Pkg; Pkg.add("Revise"; preserve=Pkg.PRESERVE_ALL); Pkg.add("PProf"; preserve=Pkg.PRESERVE_ALL); Pkg.instantiate()'; \
     fi
 RUN mkdir -p /root/.julia/config
 

--- a/add_me_to_your_PATH/sysimage.jl
+++ b/add_me_to_your_PATH/sysimage.jl
@@ -19,7 +19,7 @@ if isempty(project.dependencies) || values(project.dependencies) ⊆ keys(Pkg.Ty
     exit(0)
 end
 
-Pkg.add(name="PackageCompiler", version="1")
+Pkg.add(name="PackageCompiler", version="1"; preserve=Pkg.PRESERVE_ALL)
 
 using PackageCompiler, UUIDs
 


### PR DESCRIPTION
When adding default Revise and PProf (which are totally arbitrary things to put into the base project environment...), add `preserve=Pkg.PRESERVE_ALL` kwarg per @ssfrr's suggestion.