### PR TITLE
Cleanup `Dockerfile.template`

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -28,7 +28,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
       - name: Generate project
         run: |
-          mkdir julia_pod dev
+          mkdir julia_pod dev src
           echo "Example" >julia_pod/sysimage.packages
           cp add_me_to_your_PATH/sysimage.jl add_me_to_your_PATH/startup.jl julia_pod/
           JULIA_PKG_PRECOMPILE_AUTO=0 julia --project=. -e 'using Pkg; Pkg.add(["Example", "Mocking"])'

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,46 @@
+name: Docker
+on:
+  pull_request:
+    paths:
+      - add_me_to_your_PATH/Dockerfile.template
+      - .github/workflows/docker.yaml
+
+# Each PR and each commit on `main` use distinct concurrency groups. Note canceling workflows in
+# progress may result in having to rebuild layers as the Docker layer caching is only uploaded
+# once the image has been fully built. That said, new commits may invalidate these layers anyway.
+concurrency:
+  group: image-build-${{ github.ref_name }}-${{ github.ref == 'refs/heads/main' && github.run_number }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Image Build
+    runs-on: ubuntu-latest
+    env:
+      # Reference the HEAD commit which triggerred this workflow. By default PRs use a merge commit
+      SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ env.SHA }}  # Always checkout HEAD commit
+          fetch-depth: 0  # Needed for `git describe`
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Generate project
+        run: |
+          mkdir julia_pod dev
+          echo "Example" >julia_pod/sysimage.packages
+          julia --project=. -e 'using Pkg; Pkg.add(["Example", "Mocking"])'
+      - name: Build
+        uses: docker/build-push-action@v4
+        with:
+          # Use Path context to ensure that the `.git` directory is included in the image.
+          # https://github.com/docker/build-push-action#git-context
+          context: .
+          push: false
+          file: add_me_to_your_PATH/Dockerfile.template
+          build-args: |
+            JULIA_VERSION=1
+            CUDA_VERSION=12.1.1
+          cache-from: type=gha
+          cache-to: type=gha,mode=min

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -23,7 +23,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ env.SHA }}  # Always checkout HEAD commit
-          fetch-depth: 0  # Needed for `git describe`
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Generate project

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -3,6 +3,8 @@ on:
   pull_request:
     paths:
       - add_me_to_your_PATH/Dockerfile.template
+      - add_me_to_your_PATH/sysimage.jl
+      - add_me_to_your_PATH/startup.jl
       - .github/workflows/docker.yaml
 
 # Each PR and each commit on `main` use distinct concurrency groups. Note canceling workflows in

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -43,4 +43,4 @@ jobs:
             JULIA_VERSION=1
             CUDA_VERSION=12.1.1
           cache-from: type=gha
-          cache-to: type=gha,mode=min
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Build
         uses: docker/build-push-action@v4
         with:
-          # Use Path context to ensure that the `.git` directory is included in the image.
+          # Use Path context to ensure that our generated `julia_pod` directory is included in the image.
           # https://github.com/docker/build-push-action#git-context
           context: .
           push: false

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -30,7 +30,8 @@ jobs:
         run: |
           mkdir julia_pod dev
           echo "Example" >julia_pod/sysimage.packages
-          julia --project=. -e 'using Pkg; Pkg.add(["Example", "Mocking"])'
+          cp add_me_to_your_PATH/sysimage.jl add_me_to_your_PATH/startup.jl julia_pod/
+          JULIA_PKG_PRECOMPILE_AUTO=0 julia --project=. -e 'using Pkg; Pkg.add(["Example", "Mocking"])'
       - name: Build
         uses: docker/build-push-action@v4
         with:

--- a/add_me_to_your_PATH/Dockerfile.template
+++ b/add_me_to_your_PATH/Dockerfile.template
@@ -92,17 +92,18 @@ RUN apt-get -qq update && \
     rm -rf /var/lib/apt/lists/*
 
 # Instantiate the Julia project environment
-COPY --from=sysimage-project *Project.toml *Manifest.toml /JuliaProject/
+ENV JULIA_PROJECT /JuliaProject
+COPY --from=sysimage-project Project.toml Manifest.toml ${JULIA_PROJECT}/
 
 RUN --mount=type=secret,id=github_token \
-    julia --project=/JuliaProject -e 'using Pkg; Pkg.Registry.update(); Pkg.instantiate(); Pkg.build(); Pkg.precompile()'
+    julia -e 'using Pkg; Pkg.Registry.update(); Pkg.instantiate(); Pkg.build(); Pkg.precompile()'
 
-COPY ./julia_pod/sysimage.jl /JuliaProject/sysimage.jl
+COPY ./julia_pod/sysimage.jl ${JULIA_PROJECT}/sysimage.jl
 RUN --mount=type=secret,id=github_token \
-    julia --project=/JuliaProject -e 'include("/JuliaProject/sysimage.jl")'
+    julia -e 'include("/JuliaProject/sysimage.jl")'
 
 RUN --mount=type=secret,id=github_token \
-    julia --project=/JuliaProject -e 'using Pkg; Pkg.instantiate()'
+    julia -e 'using Pkg; Pkg.instantiate()'
 
 #####
 ##### `precompile-image` stage
@@ -125,13 +126,13 @@ RUN --mount=type=secret,id=github_token \
     fi
 RUN mkdir -p /root/.julia/config
 
-COPY *Project.toml *Manifest.toml /JuliaProject/
+COPY *Project.toml *Manifest.toml ${JULIA_PROJECT}/
 
 # comment out if you don't have any `dev --local` deps
-COPY dev/ /JuliaProject/dev/
+COPY dev/ ${JULIA_PROJECT}/dev/
 
 RUN --mount=type=secret,id=github_token \
-    julia --project=/JuliaProject -e 'using Pkg; Pkg.instantiate(); Pkg.build(); Pkg.precompile()'
+    julia -e 'using Pkg; Pkg.instantiate(); Pkg.build(); Pkg.precompile()'
 
 #####
 ##### `project` initialization stage
@@ -145,8 +146,10 @@ RUN --mount=type=secret,id=github_token \
 
 FROM base as project
 
+ENV JULIA_PROJECT /JuliaProject
+
 # copy over artifacts generated during the `precompile-image` stage
-COPY --from=precompile-image /JuliaProject/ /JuliaProject/
+COPY --from=precompile-image /JuliaProject/ ${JULIA_PROJECT}/
 COPY --from=precompile-image /root/.julia /root/.julia
 COPY --from=precompile-image /usr/local/julia/lib/julia/sys.* /usr/local/julia/lib/julia/
 
@@ -155,17 +158,15 @@ COPY --from=precompile-image /usr/local/julia/lib/julia/sys.* /usr/local/julia/l
 COPY --from=precompile-image /root/.gitconfig /root/.gitconfig
 
 # copy source
-COPY src/ JuliaProject/src/
+COPY src/ ${JULIA_PROJECT}/src/
 
 # final precompilation step
-RUN julia --project=/JuliaProject -e 'using Pkg; Pkg.build(); Pkg.precompile()'
+RUN julia -e 'using Pkg; Pkg.build(); Pkg.precompile()'
 
 # copy over all other files without re-running precompile
-COPY . JuliaProject/
+COPY . ${JULIA_PROJECT}/
 
-ENV JULIA_PROJECT @.
-
-WORKDIR /JuliaProject
+WORKDIR ${JULIA_PROJECT}
 
 COPY julia_pod/startup.jl /root/.julia/config/startup.jl
 

--- a/add_me_to_your_PATH/Dockerfile.template
+++ b/add_me_to_your_PATH/Dockerfile.template
@@ -99,8 +99,11 @@ RUN --mount=type=secret,id=github_token \
     julia -e 'using Pkg; Pkg.Registry.update(); Pkg.instantiate(); Pkg.build(); Pkg.precompile(strict=true)'
 
 COPY ./julia_pod/sysimage.jl ${JULIA_PROJECT}/sysimage.jl
+ARG SYSIMAGE="true"
 RUN --mount=type=secret,id=github_token \
-    julia -e 'include("/JuliaProject/sysimage.jl")'
+    if [ "$SYSIMAGE" = "true" ]; then \
+        julia -e 'include("/JuliaProject/sysimage.jl")'; \
+    fi
 
 RUN --mount=type=secret,id=github_token \
     julia -e 'using Pkg; Pkg.instantiate()'

--- a/add_me_to_your_PATH/Dockerfile.template
+++ b/add_me_to_your_PATH/Dockerfile.template
@@ -8,7 +8,7 @@ ARG CUDA_VERSION
 # Extract Project.toml with pinned deps only + corresponding Manifest.toml
 FROM julia:${JULIA_VERSION}-buster as sysimage-project
 
-COPY Project.toml Manifest.toml ./julia_pod/sysimage.packages .
+COPY Project.toml Manifest.toml ./julia_pod/sysimage.packages* .
 
 # (stdlibs count as pinned)
 RUN julia --project=. -e 'using Pkg;\
@@ -16,7 +16,7 @@ RUN julia --project=. -e 'using Pkg;\
                                           if !p.is_tracking_registry]; \
                           registered = [p.name for p in values(Pkg.dependencies()) \
                                         if p.is_tracking_registry]; \
-                          previous = readlines("sysimage.packages"); \
+                          previous = isfile("sysimage.packages") ? readlines("sysimage.packages") : String[]; \
                           rm_deps = union(unregistered, setdiff(registered, previous)); \
                           println("removing $rm_deps"); \
                           isempty(rm_deps) || Pkg.rm(rm_deps; mode=Pkg.PKGMODE_MANIFEST); \

--- a/add_me_to_your_PATH/Dockerfile.template
+++ b/add_me_to_your_PATH/Dockerfile.template
@@ -66,8 +66,9 @@ ENV JULIA_DEBUG CUDA
 ENV CUDA_HOME /usr/local/cuda
 ENV PYTHON ""
 
-# Install github-token-helper to allow for private repo access via `docker build --secret id=github_token,src=token.txt ...`
-RUN curl -L https://raw.githubusercontent.com/beacon-biosignals/github-token-helper/v0.1.2/github-token-helper -o $HOME/.github-token-helper && \
+# Supports private repo access via Docker build secrets (e.g. `docker build --secret id=github_token,...`):
+# https://docs.docker.com/engine/reference/commandline/buildx_build/#secret
+RUN curl -sSL https://raw.githubusercontent.com/beacon-biosignals/github-token-helper/v0.1.2/github-token-helper -o $HOME/.github-token-helper && \
     chmod +x $HOME/.github-token-helper && \
     git config --global credential.https://github.com.helper "$HOME/.github-token-helper -f /run/secrets/github_token"
 

--- a/add_me_to_your_PATH/Dockerfile.template
+++ b/add_me_to_your_PATH/Dockerfile.template
@@ -156,10 +156,6 @@ COPY --from=precompile-image /JuliaProject/ ${JULIA_PROJECT}/
 COPY --from=precompile-image /root/.julia /root/.julia
 COPY --from=precompile-image /usr/local/julia/lib/julia/sys.* /usr/local/julia/lib/julia/
 
-# contains github token, you may want to remove this file
-# but then adding private deps during julia_pod sessions will not work
-COPY --from=precompile-image /root/.gitconfig /root/.gitconfig
-
 # copy source
 COPY src/ ${JULIA_PROJECT}/src/
 

--- a/add_me_to_your_PATH/Dockerfile.template
+++ b/add_me_to_your_PATH/Dockerfile.template
@@ -40,8 +40,14 @@ RUN if ! julia --history-file=no -e 'exit(0)'; then \
         exit 1; \
     fi
 
-RUN apt-get update && \
-    apt-get install -y curl git && \
+# Reduces output from `apt-get`
+ENV DEBIAN_FRONTEND noninteractive
+
+# Installing required system packages:
+# - `curl`: Required for installing github-token-helper
+# - `git`: Required for installing github-token-helper
+RUN apt-get -qq update && \
+    apt-get -qq install curl git && \
     rm -rf /var/lib/apt/lists/*
 
 ENV JULIA_CUDA_USE_BINARYBUILDER="false"
@@ -64,12 +70,10 @@ RUN --mount=type=secret,id=github_token \
 
 FROM base as sysimage-image
 
-# Install system dependencies needed to instantiate the environment and build
-# sysimage. Based on Docker's best practices w.r.t. apt-get:
-# https://docs.docker.com/develop/develop-images/dockerfile_best-practices/
-
-RUN apt-get update && \
-    apt-get install -y gcc && \
+# Installing required system packages:
+# - `gcc`: Required for PackageCompiler.jl
+RUN apt-get -qq update && \
+    apt-get -qq install gcc && \
     rm -rf /var/lib/apt/lists/*
 
 # Instantiate the Julia project environment

--- a/add_me_to_your_PATH/Dockerfile.template
+++ b/add_me_to_your_PATH/Dockerfile.template
@@ -132,7 +132,7 @@ RUN mkdir -p /root/.julia/config
 COPY *Project.toml *Manifest.toml ${JULIA_PROJECT}/
 
 # comment out if you don't have any `dev --local` deps
-COPY dev/ ${JULIA_PROJECT}/dev/
+COPY dev* ${JULIA_PROJECT}/dev/
 
 RUN --mount=type=secret,id=github_token \
     julia -e 'using Pkg; Pkg.instantiate(); Pkg.build(); Pkg.precompile(strict=true)'

--- a/add_me_to_your_PATH/Dockerfile.template
+++ b/add_me_to_your_PATH/Dockerfile.template
@@ -8,12 +8,13 @@ ARG CUDA_VERSION
 ##### `sysimage-project` stage
 #####
 
-# Extract Project.toml with pinned deps only + corresponding Manifest.toml
 FROM julia:${JULIA_VERSION}-buster as sysimage-project
 
 COPY Project.toml Manifest.toml ./julia_pod/sysimage.packages* .
 
-# (stdlibs count as pinned)
+# Generate a Manifest.toml which only includes packages listed in the "sysimage.packages" file
+# and their dependencies. We'll use this minimal package list to avoid invalidating the sysimage
+# generation as much as possible.
 RUN julia --project=. -e 'using Pkg;\
                           unregistered = [p.name for p in values(Pkg.dependencies()) \
                                           if !p.is_tracking_registry]; \
@@ -86,6 +87,9 @@ RUN --mount=type=secret,id=github_token \
 ##### `sysimage-image` stage
 #####
 
+# The sysimage stage is designed to be invalidated as infrequently as
+# possible while making a sysimage for faster Julia load times.
+
 FROM base as sysimage-image
 
 # Installing required system packages:
@@ -114,13 +118,6 @@ RUN --mount=type=secret,id=github_token \
 #####
 ##### `precompile-image` stage
 #####
-
-# The sysimage stage is designed to be invalidated as infrequently as
-# possible while making a sysimage for faster julia load times.
-# In particular, it only depends on the 'Manifest.toml' containing
-# pinned dependencies only, which by julia_pod convention
-# is the set of dependencies that will go into the sysimage.
-
 
 FROM sysimage-image as precompile-image
 

--- a/add_me_to_your_PATH/Dockerfile.template
+++ b/add_me_to_your_PATH/Dockerfile.template
@@ -96,7 +96,7 @@ ENV JULIA_PROJECT /JuliaProject
 COPY --from=sysimage-project Project.toml Manifest.toml ${JULIA_PROJECT}/
 
 RUN --mount=type=secret,id=github_token \
-    julia -e 'using Pkg; Pkg.Registry.update(); Pkg.instantiate(); Pkg.build(); Pkg.precompile()'
+    julia -e 'using Pkg; Pkg.Registry.update(); Pkg.instantiate(); Pkg.build(); Pkg.precompile(strict=true)'
 
 COPY ./julia_pod/sysimage.jl ${JULIA_PROJECT}/sysimage.jl
 RUN --mount=type=secret,id=github_token \
@@ -132,7 +132,7 @@ COPY *Project.toml *Manifest.toml ${JULIA_PROJECT}/
 COPY dev/ ${JULIA_PROJECT}/dev/
 
 RUN --mount=type=secret,id=github_token \
-    julia -e 'using Pkg; Pkg.instantiate(); Pkg.build(); Pkg.precompile()'
+    julia -e 'using Pkg; Pkg.instantiate(); Pkg.build(); Pkg.precompile(strict=true)'
 
 #####
 ##### `project` initialization stage
@@ -161,7 +161,7 @@ COPY --from=precompile-image /root/.gitconfig /root/.gitconfig
 COPY src/ ${JULIA_PROJECT}/src/
 
 # final precompilation step
-RUN julia -e 'using Pkg; Pkg.build(); Pkg.precompile()'
+RUN julia -e 'using Pkg; Pkg.build(); Pkg.precompile(strict=true)'
 
 # copy over all other files without re-running precompile
 COPY . ${JULIA_PROJECT}/

--- a/add_me_to_your_PATH/Dockerfile.template
+++ b/add_me_to_your_PATH/Dockerfile.template
@@ -1,3 +1,6 @@
+# Available version numbers can be found here:
+# - JULIA_VERSION: https://hub.docker.com/_/julia/tags?name=-buster&ordering=name
+# - CUDA_VERSION: https://hub.docker.com/r/nvidia/cuda/tags?name=-cudnn8-devel-ubuntu20.04&ordering=name
 ARG JULIA_VERSION
 ARG CUDA_VERSION
 

--- a/add_me_to_your_PATH/Dockerfile.template
+++ b/add_me_to_your_PATH/Dockerfile.template
@@ -1,8 +1,11 @@
 ARG JULIA_VERSION
 ARG CUDA_VERSION
 
-# Extract Project.toml with pinned deps only + corresponding Manifest.toml
+#####
+##### `sysimage-project` stage
+#####
 
+# Extract Project.toml with pinned deps only + corresponding Manifest.toml
 FROM julia:${JULIA_VERSION}-buster as sysimage-project
 
 COPY Project.toml Manifest.toml ./julia_pod/sysimage.packages .
@@ -23,7 +26,15 @@ RUN julia --project=. -e 'using Pkg;\
                           isempty(rm_deps) || Pkg.rm(rm_deps; mode=Pkg.PKGMODE_PROJECT); \
                           println(filter(contains(Regex(join(rm_deps, "|"))), readlines("Project.toml")))'
 
+#####
+##### `julia-base` stage
+#####
+
 FROM julia:${JULIA_VERSION}-buster as julia-base
+
+#####
+##### `base` stage
+#####
 
 FROM nvidia/cuda:${CUDA_VERSION}-cudnn8-devel-ubuntu20.04 as base
 
@@ -67,6 +78,9 @@ RUN --mount=type=secret,id=github_token \
               !isempty(ENV["PRIVATE_REGISTRY_URL"]) && Pkg.Registry.add(RegistrySpec(url=ENV["PRIVATE_REGISTRY_URL"])); \
               Pkg.Registry.add("General")'
 
+#####
+##### `sysimage-image` stage
+#####
 
 FROM base as sysimage-image
 
@@ -90,8 +104,9 @@ RUN --mount=type=secret,id=github_token \
     julia --project=/JuliaProject -e 'using Pkg; Pkg.instantiate()'
 
 #####
-##### sysimage stage (above)
+##### `precompile-image` stage
 #####
+
 # The sysimage stage is designed to be invalidated as infrequently as
 # possible while making a sysimage for faster julia load times.
 # In particular, it only depends on the 'Manifest.toml' containing
@@ -118,8 +133,9 @@ RUN --mount=type=secret,id=github_token \
     julia --project=/JuliaProject -e 'using Pkg; Pkg.instantiate(); Pkg.build(); Pkg.precompile()'
 
 #####
-##### project initialization stage
+##### `project` initialization stage
 #####
+
 # By separating this stage out from the previous stages, we achieve nicer cache
 # invalidation behavior, a slimmer final image.
 # In particular, changing content in

--- a/add_me_to_your_PATH/Dockerfile.template
+++ b/add_me_to_your_PATH/Dockerfile.template
@@ -105,7 +105,7 @@ COPY ./julia_pod/sysimage.jl ${JULIA_PROJECT}/sysimage.jl
 ARG SYSIMAGE="true"
 RUN --mount=type=secret,id=github_token \
     if [ "$SYSIMAGE" = "true" ]; then \
-        julia -e 'include("/JuliaProject/sysimage.jl")'; \
+        julia ${JULIA_PROJECT}/sysimage.jl; \
     fi
 
 RUN --mount=type=secret,id=github_token \

--- a/add_me_to_your_PATH/Dockerfile.template
+++ b/add_me_to_your_PATH/Dockerfile.template
@@ -27,15 +27,23 @@ FROM julia:${JULIA_VERSION}-buster as julia-base
 
 FROM nvidia/cuda:${CUDA_VERSION}-cudnn8-devel-ubuntu20.04 as base
 
-# ubuntu 20.04 is derived from debian buster
+# Ubuntu 20.04 based upon Debian Buster. See `/etc/debian_version` in the Ubuntu image.
 COPY --from=julia-base /usr/local/julia /usr/local/julia
+
+ENV JULIA_PATH /usr/local/julia
+ENV PATH $JULIA_PATH/bin:$PATH
+
+# Validate the architecture of the Julia executable is compatible with the CUDA container.
+RUN if ! julia --history-file=no -e 'exit(0)'; then \
+        uname -m && \
+        readelf -h ${JULIA_PATH}/bin/julia && \
+        exit 1; \
+    fi
 
 RUN apt-get update && \
     apt-get install -y curl git && \
     rm -rf /var/lib/apt/lists/*
 
-ENV JULIA_PATH /usr/local/julia
-ENV PATH $JULIA_PATH/bin:$PATH
 ENV JULIA_CUDA_USE_BINARYBUILDER="false"
 ENV JULIA_DEBUG CUDA
 ENV CUDA_HOME /usr/local/cuda

--- a/add_me_to_your_PATH/Dockerfile.template
+++ b/add_me_to_your_PATH/Dockerfile.template
@@ -121,11 +121,11 @@ RUN --mount=type=secret,id=github_token \
 
 FROM sysimage-image as precompile-image
 
-# install Revise and PProf, even if not a dep of project
+# Optionally install the Revise and PProf packages without adding it to the project
 ARG ADD_UTILS="true"
 RUN --mount=type=secret,id=github_token \
     if [ "$ADD_UTILS" = "true" ]; then \
-        julia -e 'using Pkg; Pkg.add("Revise"; preserve=Pkg.PRESERVE_ALL); Pkg.add("PProf"; preserve=Pkg.PRESERVE_ALL); Pkg.instantiate()'; \
+        JULIA_PROJECT="" julia -e 'using Pkg; Pkg.add(["Revise", "PProf"]; preserve=Pkg.PRESERVE_ALL)'; \
     fi
 RUN mkdir -p /root/.julia/config
 


### PR DESCRIPTION
Depends on #67

Minor changes to the `Dockerfile.template`:

- Provide links to where users can find the valid argument values for `JULIA_VERSION` and `CUDA_VERSION`
- Add comment headers for each stage
- Comment on what the `sysimage-project` stage code is doing
- Make `sysimage.packages` an optional dependency
- Validate that the `julia` executable and CUDA image's have compatible architectures. Without this check it's possible to say accidentally copy in an ARM64 `julia` executable into a AMD64 CUDA container. Mainly, this can occur when one of the referenced images isn't setup as multi-architecture image.
- Reduce output from `apt-get`
- Comment on why system packages are required to be installed
- Avoid showing progress bar when downloading `github-token-helper`
- Use `JULIA_PROJECT` to avoid having to specify `--project` for each Julia command
- Make generating the system image optional (opt-out)
- Install utility packages into the Julia project associated with the Julia version. This avoids having Revise and PProf show up when showing the `Pkg.status`
- Copying the `.gitconfig` is no longer needed. The GitHub token is no longer present inside of the container