### PR TITLE
add PkgCompiler to root env, not package environment

### DIFF
--- a/add_me_to_your_PATH/Dockerfile.template
+++ b/add_me_to_your_PATH/Dockerfile.template
@@ -149,7 +149,7 @@ RUN --mount=type=cache,sharing=locked,target=/tmp/julia-cache \
 # Install required dependencies for sysimage.jl
 RUN --mount=type=cache,sharing=locked,target=/tmp/julia-cache \
     --mount=type=secret,id=github_token \
-    julia -e 'using Pkg; Pkg.add(PackageSpec(name="PackageCompiler", version="1"); preserve=Pkg.PRESERVE_ALL)'
+    julia -e 'using Pkg; Pkg.activate(); Pkg.add(PackageSpec(name="PackageCompiler", version="1"); preserve=Pkg.PRESERVE_ALL)'
 
 # Generate the replacement sysimage. As the system image creation process only performs minor mutations to the
 # cache we'll use "shared" access to improve performance (only the "manifest_usage.toml" is modified).


### PR DESCRIPTION
When building a docker image for a project that is also a package, resolve fails on [step 4/6](https://github.com/beacon-biosignals/julia_pod/blob/4509dc7dfdc226c5d0f883b98e78976542dff988/add_me_to_your_PATH/Dockerfile.template#L149-L152), complaining about missing the `src/MyPackage.jl` file.  I think this is caused by the fact that the `base` image ONLY contains the project.toml/manifest.toml file and nothing else.  This PR works around this error by adding PkgCompiler to the global environment, rather than to the project environment.  Since we're now only copying out the .so from this image, teh global environment is a throwaway.