### PR TITLE
Build Docker image using a named Project.toml

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -32,7 +32,12 @@ jobs:
           mkdir julia_pod dev src
           echo "Example" >julia_pod/sysimage.packages
           cp add_me_to_your_PATH/sysimage.jl add_me_to_your_PATH/startup.jl julia_pod/
-          JULIA_PKG_PRECOMPILE_AUTO=0 julia --project=. -e 'using Pkg; Pkg.add(["Example", "Mocking"])'
+          JULIA_PKG_PRECOMPILE_AUTO=0 julia --project=. -e '
+              using Pkg;
+              Pkg.generate("CITest");
+              Pkg.activate("CITest");
+              Pkg.add(["Example", "Mocking"])'
+          mv CITest/* .
       - name: Build
         uses: docker/build-push-action@v4
         with:


### PR DESCRIPTION
Validating that this generates a failure when building the system image. #70 should fix this and I'll cherry-pick this test into that PR.