### PR TITLE
remove precompile image stage from build script

### DIFF
--- a/add_me_to_your_PATH/build_image
+++ b/add_me_to_your_PATH/build_image
@@ -100,12 +100,10 @@ fi
 mkdir -p dev
 
 VERSIONS_TAG="cuda-${CUDA_VERSION}_julia-${JULIA_VERSION}"
-DEPS_SHA="precompiled-$(sha1sum Project.toml Manifest.toml | sha1sum | head -c7)"
 
 # CACHE TAGs, designed to only change if cache images change (can we get a hash from the image itself instead?)
 BASE_IMAGE_CACHE="${IMAGE_REPO}:${VERSIONS_TAG}_base"
 SYSIMAGE_IMAGE_CACHE="${IMAGE_REPO}:${VERSIONS_TAG}_sysimage"
-PRECOMPILE_IMAGE_CACHE="${IMAGE_REPO}:${VERSIONS_TAG}_${DEPS_SHA}"
 
 DOCKER_SOURCE_HASH=$(find . -type f \( -exec sha1sum "$PWD"/{} \; \) | grep -v 'driver-' | sort -z | sha1sum | head -c7)
 GIT_REPO=$(git config --get remote.origin.url | grep -o '[^:/]*$' | head -c-5)
@@ -142,19 +140,6 @@ docker buildx build -f julia_pod/Dockerfile \
                     --cache-from "$SYSIMAGE_IMAGE_CACHE" \
                     -t "$SYSIMAGE_IMAGE_CACHE" .
 
-log "building and loading precompile-image with TAG = $PRECOMPILE_IMAGE_CACHE"
-
-docker buildx build -f julia_pod/Dockerfile \
-                    --target precompile-image \
-                    --build-arg "BUILDKIT_INLINE_CACHE=1" \
-                    --build-arg "JULIA_VERSION=$JULIA_VERSION" \
-                    --build-arg "CUDA_VERSION=$CUDA_VERSION" \
-                    ${BUILD_ARGS[@]} \
-                    --cache-from "$BASE_IMAGE_CACHE" \
-                    --cache-from "$SYSIMAGE_IMAGE_CACHE" \
-                    --cache-from "$PRECOMPILE_IMAGE_CACHE" \
-                    -t "$PRECOMPILE_IMAGE_CACHE" .
-
 log "building and pushing image with ECR_TAG = $IMAGE_TAG"
 
 docker buildx build -f julia_pod/Dockerfile \
@@ -164,12 +149,10 @@ docker buildx build -f julia_pod/Dockerfile \
                     ${BUILD_ARGS[@]} \
                     --cache-from "$BASE_IMAGE_CACHE" \
                     --cache-from "$SYSIMAGE_IMAGE_CACHE" \
-                    --cache-from "$PRECOMPILE_IMAGE_CACHE" \
                     --cache-from "$IMAGE_TAG" \
                     -t "$IMAGE_TAG" .
 
 log "IMAGE_REPO=$IMAGE_REPO"
 log "BASE_IMAGE_CACHE=$BASE_IMAGE_CACHE"
 log "SYSIMAGE_IMAGE_CACHE=$SYSIMAGE_IMAGE_CACHE"
-log "PRECOMPILE_IMAGE_CACHE=$PRECOMPILE_IMAGE_CACHE"
 log "IMAGE_TAG=$IMAGE_TAG"


### PR DESCRIPTION
This stage was removed from the dockerfile in #69 

Ideally we'd _test_ this `build_image` script somehow, but since it interacts with ECR I'm not sure how to handle that...